### PR TITLE
Reorder layout to emphasize map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,55 +108,57 @@ export default function App() {
       </header>
       <main className={styles.main}>
         <div className={styles.leftColumn}>
-          <DataPanel />
+          <section className={styles.visualizationSection}>
+            <Tabs
+              options={VIEW_OPTIONS.map((option) => ({ id: option.id, label: option.label }))}
+              activeId={view}
+              onChange={handleViewChange}
+            />
+            {players.length === 0 ? (
+              <p className={styles.placeholder}>Load player data to render the map.</p>
+            ) : (
+              <div className={styles.visualization}>
+                {view === 'decade' && decadeFocus != null && (
+                  <div className={styles.decadeControl}>
+                    <label htmlFor="decade-slider">Focus decade: {decadeFocus}s</label>
+                    <input
+                      id="decade-slider"
+                      type="range"
+                      min={0}
+                      max={decades.length - 1}
+                      value={decades.indexOf(decadeFocus)}
+                      onChange={(event) => {
+                        const index = Number(event.target.value);
+                        setDecadeFocus(decades[index] ?? decadeFocus);
+                      }}
+                    />
+                  </div>
+                )}
+                <MapView
+                  metric={view === 'warPerMillion' ? 'warPerMillion' : 'totalWar'}
+                  aggregates={aggregates}
+                  onStateHover={handleHover}
+                  onStateSelect={handleSelect}
+                  selectedFips={selectedInfo?.fips ?? null}
+                  title={
+                    view === 'warPerMillion'
+                      ? 'Career WAR per 1M residents'
+                      : view === 'decade'
+                        ? `Career WAR by birthplace · ${decadeFocus ?? ''}s`
+                        : 'Total career WAR by birthplace'
+                  }
+                />
+                <Tooltip
+                  aggregate={tooltipAggregate}
+                  position={tooltipPosition ?? null}
+                  visible={Boolean(tooltipAggregate)}
+                  pinned={tooltipPinned}
+                />
+              </div>
+            )}
+          </section>
           <FiltersPanel />
-          <Tabs
-            options={VIEW_OPTIONS.map((option) => ({ id: option.id, label: option.label }))}
-            activeId={view}
-            onChange={handleViewChange}
-          />
-          {players.length === 0 ? (
-            <p className={styles.placeholder}>Load player data to render the map.</p>
-          ) : (
-            <div className={styles.visualization}>
-              {view === 'decade' && decadeFocus != null && (
-                <div className={styles.decadeControl}>
-                  <label htmlFor="decade-slider">Focus decade: {decadeFocus}s</label>
-                  <input
-                    id="decade-slider"
-                    type="range"
-                    min={0}
-                    max={decades.length - 1}
-                    value={decades.indexOf(decadeFocus)}
-                    onChange={(event) => {
-                      const index = Number(event.target.value);
-                      setDecadeFocus(decades[index] ?? decadeFocus);
-                    }}
-                  />
-                </div>
-              )}
-              <MapView
-                metric={view === 'warPerMillion' ? 'warPerMillion' : 'totalWar'}
-                aggregates={aggregates}
-                onStateHover={handleHover}
-                onStateSelect={handleSelect}
-                selectedFips={selectedInfo?.fips ?? null}
-                title={
-                  view === 'warPerMillion'
-                    ? 'Career WAR per 1M residents'
-                    : view === 'decade'
-                      ? `Career WAR by birthplace · ${decadeFocus ?? ''}s`
-                      : 'Total career WAR by birthplace'
-                }
-              />
-              <Tooltip
-                aggregate={tooltipAggregate}
-                position={tooltipPosition ?? null}
-                visible={Boolean(tooltipAggregate)}
-                pinned={tooltipPinned}
-              />
-            </div>
-          )}
+          <DataPanel />
         </div>
         <StateDetailPanel aggregate={selectedAggregate ?? null} page={detailPage} onPageChange={setDetailPage} />
       </main>

--- a/src/styles/App.module.css
+++ b/src/styles/App.module.css
@@ -28,6 +28,13 @@
   flex-direction: column;
 }
 
+.visualizationSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
 .visualization {
   position: relative;
   min-height: 480px;


### PR DESCRIPTION
## Summary
- move the map visualization (with view tabs and controls) to the top of the left column
- render the filters panel directly beneath the map and shift the data panel to the bottom of the stack
- add layout spacing to support the new section order

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d566ce3f988327b545dd63cef69df0