### PR TITLE
Align filter sliders with decade increments

### DIFF
--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -17,8 +17,10 @@ export function FiltersPanel() {
     return null;
   }
 
-  const globalMin = Math.min(...players.map((player) => player.birthYear));
-  const globalMax = Math.max(...players.map((player) => player.birthYear));
+  const rawMin = Math.min(...players.map((player) => player.birthYear));
+  const rawMax = Math.max(...players.map((player) => player.birthYear));
+  const sliderMin = snapToDecade(rawMin);
+  const sliderMax = Math.ceil(rawMax / 10) * 10;
 
   const handleMinYearChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = snapToDecade(Number(event.target.value));
@@ -56,8 +58,8 @@ export function FiltersPanel() {
           <input
             id="birth-min"
             type="range"
-            min={globalMin}
-            max={globalMax}
+            min={sliderMin}
+            max={sliderMax}
             step={10}
             value={filters.minYear}
             onChange={handleMinYearChange}
@@ -65,8 +67,8 @@ export function FiltersPanel() {
           <input
             id="birth-max"
             type="range"
-            min={globalMin}
-            max={globalMax}
+            min={sliderMin}
+            max={sliderMax}
             step={10}
             value={filters.maxYear}
             onChange={handleMaxYearChange}

--- a/src/context/DataContext.tsx
+++ b/src/context/DataContext.tsx
@@ -73,6 +73,9 @@ const defaultFilters: Filters = {
   league: 'all'
 };
 
+const snapYearDownToDecade = (value: number) => Math.floor(value / 10) * 10;
+const snapYearUpToDecade = (value: number) => Math.ceil(value / 10) * 10;
+
 export function DataProvider({ children }: { children: React.ReactNode }) {
   const storedPlayers = useLocalStorage(PLAYERS_STORAGE_KEY);
   const storedPopulations = useLocalStorage(POP_STORAGE_KEY);
@@ -279,12 +282,20 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (players.length === 0) {
-      setFilters((prev) => ({ ...prev, minYear: defaultFilters.minYear, maxYear: defaultFilters.maxYear }));
+      setFilters((prev) => ({
+        ...prev,
+        minYear: snapYearDownToDecade(defaultFilters.minYear),
+        maxYear: snapYearUpToDecade(defaultFilters.maxYear)
+      }));
       return;
     }
     const minYear = Math.min(...players.map((player) => player.birthYear));
     const maxYear = Math.max(...players.map((player) => player.birthYear));
-    setFilters((prev) => ({ ...prev, minYear, maxYear }));
+    setFilters((prev) => ({
+      ...prev,
+      minYear: snapYearDownToDecade(minYear),
+      maxYear: snapYearUpToDecade(maxYear)
+    }));
   }, [players]);
 
   const contextValue: DataContextValue = {


### PR DESCRIPTION
## Summary
- normalize stored birth year filter bounds to the nearest decade when player datasets load
- align filter slider ranges with decade boundaries so handles stay in sync across all tabs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5689eb16883278462dc403cc7ffff