### PR TITLE
Remove unused footer messaging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,11 +162,6 @@ export default function App() {
         </div>
         <StateDetailPanel aggregate={selectedAggregate ?? null} page={detailPage} onPageChange={setDetailPage} />
       </main>
-      <footer className={styles.footer}>
-        <p>
-          Drop in fresh CSV exports at any time. Data is stored locally in your browser so you can pick up where you left off.
-        </p>
-      </footer>
     </div>
   );
 }

--- a/src/styles/App.module.css
+++ b/src/styles/App.module.css
@@ -115,14 +115,6 @@
   flex: 1;
 }
 
-.footer {
-  margin-top: auto;
-  padding: 1.5rem 0 0.5rem;
-  color: rgba(226, 232, 240, 0.8);
-  font-size: 0.95rem;
-  text-align: center;
-}
-
 @media (max-width: 1080px) {
   .main {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- remove the footer element from the app layout
- clean up the unused footer styles to match the layout change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5695d378883278946378bc540bba6