### PR TITLE
Restyle interface for better contrast and readability

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,11 @@
     />
     <style>
       :root {
-        color-scheme: light dark;
+        color-scheme: dark;
         font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
           sans-serif;
-        background-color: #0f172a;
-        color: #f1f5f9;
+        background-color: #020617;
+        color: #e2e8f0;
       }
 
       body {
@@ -24,7 +24,10 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
-        background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+        background: radial-gradient(circle at 12% 18%, rgba(96, 165, 250, 0.24), transparent 42%),
+          radial-gradient(circle at 80% 10%, rgba(192, 132, 252, 0.22), transparent 48%),
+          radial-gradient(circle at 50% 90%, rgba(34, 197, 94, 0.2), transparent 38%),
+          linear-gradient(155deg, #020617 0%, #0b1120 45%, #111827 100%);
       }
 
       header {
@@ -43,7 +46,7 @@
         margin: 0 auto;
         max-width: 60ch;
         line-height: 1.6;
-        color: #cbd5f5;
+        color: rgba(203, 213, 225, 0.78);
         font-size: 1rem;
       }
 
@@ -58,9 +61,9 @@
       #map-container {
         width: min(1100px, 100%);
         aspect-ratio: 16 / 9;
-        background: rgba(15, 23, 42, 0.85);
+        background: linear-gradient(160deg, rgba(15, 23, 42, 0.86), rgba(15, 23, 42, 0.95));
         border-radius: 16px;
-        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.5);
+        box-shadow: 0 32px 55px -26px rgba(8, 11, 26, 0.75);
         padding: clamp(12px, 2vw, 24px);
       }
 
@@ -70,10 +73,10 @@
       }
 
       .country {
-        fill: #1d4ed8;
-        stroke: #0f172a;
+        fill: #3b82f6;
+        stroke: rgba(8, 12, 26, 0.85);
         stroke-width: 0.4px;
-        fill-opacity: 0.7;
+        fill-opacity: 0.55;
       }
 
       .state {
@@ -87,7 +90,7 @@
         text-align: center;
         padding: 1.5rem;
         font-size: 0.85rem;
-        color: #94a3b8;
+        color: rgba(148, 163, 184, 0.8);
       }
 
       a {

--- a/src/styles/App.module.css
+++ b/src/styles/App.module.css
@@ -6,6 +6,7 @@
   margin: 0;
   padding: clamp(1.5rem, 3vw, 3rem) clamp(1.5rem, 6vw, 5rem);
   gap: clamp(1.5rem, 3vw, 2.25rem);
+  color: var(--text-primary);
 }
 
 .header {
@@ -13,7 +14,7 @@
   padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2.75rem);
   border-radius: 1.75rem;
   border: 1px solid var(--border-soft);
-  background: var(--surface-glass);
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.82));
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(18px);
   overflow: hidden;
@@ -23,8 +24,9 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.14), transparent 60%);
+  background: radial-gradient(circle at 15% 15%, rgba(96, 165, 250, 0.4), transparent 55%),
+    radial-gradient(circle at 85% 80%, rgba(192, 132, 252, 0.32), transparent 62%),
+    radial-gradient(circle at 50% 100%, rgba(34, 211, 238, 0.22), transparent 68%);
   pointer-events: none;
   mix-blend-mode: screen;
 }
@@ -35,6 +37,7 @@
   letter-spacing: -0.02em;
   position: relative;
   z-index: 1;
+  color: var(--text-strong);
 }
 
 .subtitle {
@@ -73,22 +76,22 @@
   padding: clamp(1.5rem, 2.75vw, 2.25rem);
   border-radius: 1.25rem;
   border: 1px solid var(--border-soft);
-  background: rgba(15, 23, 42, 0.02);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), var(--shadow-soft);
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.92));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
 .placeholder {
-  border: 1px dashed rgba(148, 163, 184, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.45);
   padding: 2.5rem;
   text-align: center;
   border-radius: 1.25rem;
   color: var(--text-muted);
   font-style: italic;
-  background: rgba(15, 23, 42, 0.04);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  background: rgba(15, 23, 42, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
 }
 
 .decadeControl {
@@ -97,9 +100,10 @@
   gap: 1rem;
   padding: 0.85rem 1rem;
   border-radius: 0.9rem;
-  background: rgba(37, 99, 235, 0.08);
-  border: 1px solid rgba(37, 99, 235, 0.2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  background: rgba(37, 99, 235, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  box-shadow: inset 0 1px 0 rgba(148, 197, 255, 0.35);
+  color: var(--text-strong);
 }
 
 .decadeControl label {

--- a/src/styles/DataPanel.module.css
+++ b/src/styles/DataPanel.module.css
@@ -2,12 +2,13 @@
   border: 1px solid var(--border-soft);
   padding: 1.5rem;
   border-radius: 1.25rem;
-  background: var(--surface-glass);
+  background: linear-gradient(160deg, var(--surface-glass) 0%, rgba(8, 12, 26, 0.92) 100%);
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(16px);
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  color: var(--text-primary);
 }
 
 .headingRow {
@@ -20,6 +21,7 @@
 .headingRow h2 {
   margin: 0;
   font-size: 1.35rem;
+  color: var(--text-strong);
 }
 
 .actions {
@@ -31,7 +33,7 @@
 .actions button {
   border: none;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #f8fafc;
+  color: var(--text-strong);
   padding: 0.55rem 1.1rem;
   border-radius: 999px;
   cursor: pointer;
@@ -94,7 +96,7 @@
 }
 
 .summaryGrid li {
-  color: #0f172a;
+  color: var(--text-primary);
   list-style: none;
   position: relative;
   padding-left: 0.9rem;
@@ -109,5 +111,5 @@
   height: 6px;
   border-radius: 50%;
   background: var(--accent);
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.22);
 }

--- a/src/styles/FiltersPanel.module.css
+++ b/src/styles/FiltersPanel.module.css
@@ -2,16 +2,18 @@
   border: 1px solid var(--border-soft);
   padding: 1.5rem;
   border-radius: 1.25rem;
-  background: var(--surface-glass);
+  background: linear-gradient(155deg, var(--surface-glass) 0%, rgba(8, 15, 32, 0.92) 100%);
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(16px);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  color: var(--text-primary);
 }
 
 .panel h2 {
   margin: 0;
+  color: var(--text-strong);
 }
 
 .filterRow {
@@ -22,7 +24,7 @@
 
 .filterRow label {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-strong);
 }
 
 .sliderRow {
@@ -36,9 +38,10 @@ input[type='range'] {
   appearance: none;
   height: 0.55rem;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--accent-soft), rgba(148, 163, 184, 0.35));
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.55), rgba(148, 163, 184, 0.25));
   position: relative;
   overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.25);
 }
 
 input[type='range']::-webkit-slider-thumb {
@@ -48,7 +51,7 @@ input[type='range']::-webkit-slider-thumb {
   height: 18px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+  box-shadow: 0 4px 12px rgba(96, 165, 250, 0.45);
   border: none;
 }
 
@@ -57,7 +60,7 @@ input[type='range']::-moz-range-thumb {
   height: 18px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+  box-shadow: 0 4px 12px rgba(96, 165, 250, 0.45);
   border: none;
 }
 
@@ -73,14 +76,15 @@ input[type='range']::-moz-range-track {
 select {
   padding: 0.5rem 0.75rem;
   border-radius: 0.75rem;
-  border: 1px solid var(--border-soft);
+  border: 1px solid var(--border-strong);
   max-width: 240px;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: rgba(15, 23, 42, 0.85);
+  box-shadow: inset 0 1px 0 rgba(148, 197, 255, 0.25), 0 12px 25px -18px rgba(8, 12, 26, 0.7);
   font-weight: 500;
+  color: var(--text-primary);
 }
 
 select:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.35);
+  outline: 2px solid rgba(96, 165, 250, 0.45);
   outline-offset: 2px;
 }

--- a/src/styles/MapView.module.css
+++ b/src/styles/MapView.module.css
@@ -10,7 +10,7 @@
   margin: 0;
   font-size: 1.45rem;
   letter-spacing: -0.01em;
-  color: #0f172a;
+  color: var(--text-strong);
 }
 
 .mapContainer {
@@ -21,18 +21,18 @@
   padding: clamp(1.25rem, 2.5vw, 2rem);
   border-radius: 1.1rem;
   border: 1px solid var(--border-soft);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.75) 0%, rgba(226, 232, 240, 0.55) 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55), var(--shadow-soft);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.86) 0%, rgba(15, 23, 42, 0.95) 100%);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18), var(--shadow-soft);
 }
 
 .svg {
   width: 100%;
   height: auto;
   border-radius: 0.95rem;
-  background: radial-gradient(circle at 30% 20%, rgba(37, 99, 235, 0.16), transparent 65%),
-    radial-gradient(circle at 80% 75%, rgba(14, 165, 233, 0.15), transparent 65%),
-    #eef2ff;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+  background: radial-gradient(circle at 28% 25%, rgba(96, 165, 250, 0.18), transparent 65%),
+    radial-gradient(circle at 82% 75%, rgba(14, 165, 233, 0.22), transparent 65%),
+    rgba(15, 23, 42, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.32);
 }
 
 .state {

--- a/src/styles/StateDetailPanel.module.css
+++ b/src/styles/StateDetailPanel.module.css
@@ -2,7 +2,7 @@
   border: 1px solid var(--border-soft);
   border-radius: 1.25rem;
   padding: 1.5rem;
-  background: var(--surface-glass);
+  background: linear-gradient(165deg, var(--surface-glass) 0%, rgba(8, 12, 26, 0.95) 100%);
   box-shadow: var(--shadow-soft);
   backdrop-filter: blur(18px);
   min-width: 260px;
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  color: var(--text-primary);
 }
 
 .panel h3 {
@@ -25,7 +26,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(15, 23, 42, 0.6);
+  color: var(--text-soft);
 }
 
 .list {
@@ -33,22 +34,22 @@
   margin: 0;
   padding: 0;
   border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.55);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.28);
 }
 
 .list li {
   display: grid;
   grid-template-columns: 1fr 70px;
   padding: 0.55rem 0.85rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
   font-size: 0.92rem;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .list li:nth-child(odd) {
-  background: rgba(37, 99, 235, 0.05);
+  background: rgba(96, 165, 250, 0.08);
 }
 
 .list li:last-child {
@@ -68,20 +69,20 @@
 
 .pagination button {
   border: none;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 118, 110, 0.9));
-  color: #f8fafc;
+  background: linear-gradient(135deg, rgba(37, 211, 204, 0.88), rgba(59, 130, 246, 0.88));
+  color: var(--text-strong);
   padding: 0.45rem 0.95rem;
   border-radius: 999px;
   cursor: pointer;
   font-weight: 600;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 25px -18px rgba(15, 23, 42, 0.7);
+  box-shadow: 0 10px 25px -18px rgba(8, 12, 26, 0.75);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .pagination button:hover:not([disabled]) {
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px -18px rgba(15, 23, 42, 0.8);
+  box-shadow: 0 12px 28px -18px rgba(37, 99, 235, 0.6);
 }
 
 .pagination button:focus-visible {

--- a/src/styles/Tabs.module.css
+++ b/src/styles/Tabs.module.css
@@ -5,9 +5,9 @@
   margin-bottom: 1.25rem;
   padding: 0.4rem;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.06);
+  background: rgba(15, 23, 42, 0.7);
   border: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.25), 0 12px 30px -20px rgba(8, 12, 26, 0.8);
 }
 
 .tab,
@@ -17,24 +17,24 @@
   background: transparent;
   cursor: pointer;
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.65);
+  color: var(--text-soft);
   border-radius: 999px;
   transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease;
 }
 
 .tab:hover {
-  color: #0f172a;
+  color: var(--text-primary);
   transform: translateY(-1px);
 }
 
 .activeTab {
-  color: #0f172a;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0.45));
-  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.35);
+  color: var(--text-strong);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.28), rgba(37, 99, 235, 0.5));
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.4);
 }
 
 .tab:focus-visible,
 .activeTab:focus-visible {
-  outline: 3px solid rgba(59, 130, 246, 0.35);
+  outline: 3px solid rgba(96, 165, 250, 0.45);
   outline-offset: 2px;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,18 +2,23 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.6;
   font-weight: 400;
-  color: #0f172a;
+  color: #e2e8f0;
   background-color: #020617;
-  --surface-glass: rgba(255, 255, 255, 0.72);
-  --surface-muted: rgba(255, 255, 255, 0.55);
-  --border-soft: rgba(148, 163, 184, 0.45);
-  --border-strong: rgba(100, 116, 139, 0.55);
-  --text-muted: #475569;
-  --accent: #2563eb;
-  --accent-strong: #1d4ed8;
-  --accent-soft: rgba(37, 99, 235, 0.12);
-  --shadow-soft: 0 22px 45px -25px rgba(15, 23, 42, 0.45);
-  --shadow-ring: 0 0 0 1px rgba(148, 163, 184, 0.35);
+  color-scheme: dark;
+  --text-strong: #f8fafc;
+  --text-primary: #e2e8f0;
+  --text-muted: rgba(203, 213, 225, 0.78);
+  --text-soft: rgba(148, 163, 184, 0.65);
+  --surface-glass: rgba(15, 23, 42, 0.78);
+  --surface-muted: rgba(15, 23, 42, 0.55);
+  --surface-highlight: rgba(30, 64, 175, 0.35);
+  --border-soft: rgba(148, 163, 184, 0.35);
+  --border-strong: rgba(37, 211, 204, 0.4);
+  --accent: #60a5fa;
+  --accent-strong: #3b82f6;
+  --accent-soft: rgba(96, 165, 250, 0.28);
+  --shadow-soft: 0 32px 55px -26px rgba(8, 11, 26, 0.75);
+  --shadow-ring: 0 0 0 1px rgba(148, 163, 184, 0.32);
 }
 
 * {
@@ -23,12 +28,12 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background-image: radial-gradient(circle at 15% 20%, rgba(59, 130, 246, 0.18), transparent 45%),
-    radial-gradient(circle at 85% 15%, rgba(236, 72, 153, 0.16), transparent 42%),
-    radial-gradient(circle at 50% 80%, rgba(34, 197, 94, 0.18), transparent 38%),
-    linear-gradient(160deg, #0f172a 0%, #020617 100%);
+  background-image: radial-gradient(circle at 12% 18%, rgba(96, 165, 250, 0.24), transparent 42%),
+    radial-gradient(circle at 82% 10%, rgba(192, 132, 252, 0.22), transparent 48%),
+    radial-gradient(circle at 50% 85%, rgba(34, 197, 94, 0.2), transparent 38%),
+    linear-gradient(155deg, #020617 0%, #0b1120 45%, #111827 100%);
   background-attachment: fixed;
-  color: inherit;
+  color: var(--text-primary);
 }
 
 a {
@@ -40,8 +45,8 @@ button {
 }
 
 ::selection {
-  background: rgba(37, 99, 235, 0.2);
-  color: inherit;
+  background: rgba(96, 165, 250, 0.35);
+  color: var(--text-strong);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- refresh the shared color palette with a darker glassmorphism theme that improves base text contrast
- restyle core panels, filters, tabs, and map layout to use the new palette and provide clearer control states
- align the static fallback page with the refreshed styling for a consistent presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d56b06473883279d33c4f781543071