### PR TITLE
Add international dataset and page

### DIFF
--- a/public/data/intplayers.json
+++ b/public/data/intplayers.json
@@ -1,0 +1,21982 @@
+[
+  {
+    "playerId": "pujolal01",
+    "fullName": "Albert Pujols",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 101.17
+  },
+  {
+    "playerId": "clemero01",
+    "fullName": "Roberto Clemente",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Carolina",
+    "warCareer": 94.96
+  },
+  {
+    "playerId": "blylebe01",
+    "fullName": "Bert Blyleven",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Zeist",
+    "warCareer": 94.48
+  },
+  {
+    "playerId": "beltrad01",
+    "fullName": "Adrian Beltre",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 93.72
+  },
+  {
+    "playerId": "jenkife01",
+    "fullName": "Fergie Jenkins",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Chatham",
+    "warCareer": 84.12
+  },
+  {
+    "playerId": "martipe02",
+    "fullName": "Pedro Martinez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Manoguayabo",
+    "warCareer": 83.9
+  },
+  {
+    "playerId": "carewro01",
+    "fullName": "Rod Carew",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Gatun",
+    "warCareer": 81.19
+  },
+  {
+    "playerId": "mccorji01",
+    "fullName": "Jim McCormick",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Glasgow",
+    "warCareer": 76.19
+  },
+  {
+    "playerId": "walkela01",
+    "fullName": "Larry Walker",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Maple Ridge",
+    "warCareer": 72.74
+  },
+  {
+    "playerId": "palmera01",
+    "fullName": "Rafael Palmeiro",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 71.87
+  },
+  {
+    "playerId": "beltrca01",
+    "fullName": "Carlos Beltran",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Manati",
+    "warCareer": 70.03
+  },
+  {
+    "playerId": "ramirma02",
+    "fullName": "Manny Ramirez",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 69.33
+  },
+  {
+    "playerId": "canoro01",
+    "fullName": "Robinson Cano",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 68.71
+  },
+  {
+    "playerId": "rodriiv01",
+    "fullName": "Ivan Rodriguez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Manati",
+    "warCareer": 68.71
+  },
+  {
+    "playerId": "cabremi01",
+    "fullName": "Miguel Cabrera",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 67.23
+  },
+  {
+    "playerId": "alomaro01",
+    "fullName": "Roberto Alomar",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 67.01
+  },
+  {
+    "playerId": "mullato01",
+    "fullName": "Tony Mullane",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Cork",
+    "warCareer": 66.64
+  },
+  {
+    "playerId": "tiantlu01",
+    "fullName": "Luis Tiant",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Marianao",
+    "warCareer": 66.08
+  },
+  {
+    "playerId": "vottojo01",
+    "fullName": "Joey Votto",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 63.64
+  },
+  {
+    "playerId": "maricju01",
+    "fullName": "Juan Marichal",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Laguna Verde",
+    "warCareer": 62.82
+  },
+  {
+    "playerId": "jonesan01",
+    "fullName": "Andruw Jones",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 62.71
+  },
+  {
+    "playerId": "bondto01",
+    "fullName": "Tommy Bond",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Granard",
+    "warCareer": 60.88
+  },
+  {
+    "playerId": "abreubo01",
+    "fullName": "Bobby Abreu",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 60.19
+  },
+  {
+    "playerId": "suzukic01",
+    "fullName": "Ichiro Suzuki",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Nichi Kasugai-gun",
+    "warCareer": 59.97
+  },
+  {
+    "playerId": "guerrvl01",
+    "fullName": "Vladimir Guerrero",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nizao",
+    "warCareer": 59.46
+  },
+  {
+    "playerId": "quinnja01",
+    "fullName": "Jack Quinn",
+    "birthYear": 1883,
+    "birthDecade": 1880,
+    "birthCountry": "Slovakia",
+    "birthCountryRaw": "Slovakia",
+    "birthCity": "Stefurov",
+    "warCareer": 58.63
+  },
+  {
+    "playerId": "sosasa01",
+    "fullName": "Sammy Sosa",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 58.6
+  },
+  {
+    "playerId": "ramirjo01",
+    "fullName": "Jose Ramirez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 57.54
+  },
+  {
+    "playerId": "riverma01",
+    "fullName": "Mariano Rivera",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 56.26
+  },
+  {
+    "playerId": "aparilu01",
+    "fullName": "Luis Aparicio",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 55.86
+  },
+  {
+    "playerId": "lindofr01",
+    "fullName": "Francisco Lindor",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": 55.05
+  },
+  {
+    "playerId": "ortizda01",
+    "fullName": "David Ortiz",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 55.04
+  },
+  {
+    "playerId": "cruzjo01",
+    "fullName": "Jose Cruz",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arroyo",
+    "warCareer": 54.43
+  },
+  {
+    "playerId": "perezto01",
+    "fullName": "Tony Perez",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Camaguey",
+    "warCareer": 53.94
+  },
+  {
+    "playerId": "altuvjo01",
+    "fullName": "Jose Altuve",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 53.42
+  },
+  {
+    "playerId": "minosmi01",
+    "fullName": "Minnie Minoso",
+    "birthYear": 1925,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 53.23
+  },
+  {
+    "playerId": "campabe01",
+    "fullName": "Bert Campaneris",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pueblo Nuevo",
+    "warCareer": 53.06
+  },
+  {
+    "playerId": "cedence01",
+    "fullName": "Cesar Cedeno",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 53.03
+  },
+  {
+    "playerId": "cepedor01",
+    "fullName": "Orlando Cepeda",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 50.18
+  },
+  {
+    "playerId": "hernafe02",
+    "fullName": "Felix Hernandez",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 49.75
+  },
+  {
+    "playerId": "willibe02",
+    "fullName": "Bernie Williams",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 49.59
+  },
+  {
+    "playerId": "martide01",
+    "fullName": "Dennis Martinez",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Granada",
+    "warCareer": 48.68
+  },
+  {
+    "playerId": "luquedo01",
+    "fullName": "Dolf Luque",
+    "birthYear": 1890,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 48.2
+  },
+  {
+    "playerId": "whitede03",
+    "fullName": "Devon White",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Jamaica",
+    "birthCountryRaw": "Jamaica",
+    "birthCity": "Kingston",
+    "warCareer": 47.25
+  },
+  {
+    "playerId": "tejadmi01",
+    "fullName": "Miguel Tejada",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 47.13
+  },
+  {
+    "playerId": "colonba01",
+    "fullName": "Bartolo Colon",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Altamira",
+    "warCareer": 46.27
+  },
+  {
+    "playerId": "vazquja01",
+    "fullName": "Javier Vazquez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 45.61
+  },
+  {
+    "playerId": "vizquom01",
+    "fullName": "Omar Vizquel",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 45.59
+  },
+  {
+    "playerId": "correca01",
+    "fullName": "Carlos Correa",
+    "birthYear": 1994,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 45.5
+  },
+  {
+    "playerId": "fernato01",
+    "fullName": "Tony Fernandez",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 45.3
+  },
+  {
+    "playerId": "delgaca01",
+    "fullName": "Carlos Delgado",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aguadilla",
+    "warCareer": 44.36
+  },
+  {
+    "playerId": "zambrca01",
+    "fullName": "Carlos Zambrano",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": 43.87
+  },
+  {
+    "playerId": "francju01",
+    "fullName": "Julio Franco",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": 43.56
+  },
+  {
+    "playerId": "olivato01",
+    "fullName": "Tony Oliva",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": 43.07
+  },
+  {
+    "playerId": "posadjo01",
+    "fullName": "Jorge Posada",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 42.68
+  },
+  {
+    "playerId": "cansejo01",
+    "fullName": "Jose Canseco",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 42.35
+  },
+  {
+    "playerId": "aloufe01",
+    "fullName": "Felipe Alou",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 42.32
+  },
+  {
+    "playerId": "cruzne02",
+    "fullName": "Nelson Cruz",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Santa Cruz",
+    "warCareer": 42
+  },
+  {
+    "playerId": "polanpl01",
+    "fullName": "Placido Polanco",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 41.87
+  },
+  {
+    "playerId": "bogaexa01",
+    "fullName": "Xander Bogaerts",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Aruba",
+    "birthCountryRaw": "Aruba",
+    "birthCity": "Oranjestad",
+    "warCareer": 41.84
+  },
+  {
+    "playerId": "molinya01",
+    "fullName": "Yadier Molina",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 41.59
+  },
+  {
+    "playerId": "valenfe01",
+    "fullName": "Fernando Valenzuela",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Navojoa",
+    "warCareer": 41.43
+  },
+  {
+    "playerId": "pascuca02",
+    "fullName": "Camilo Pascual",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 40.86
+  },
+  {
+    "playerId": "conceda01",
+    "fullName": "Dave Concepcion",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ocumare de la Costa",
+    "warCareer": 40.13
+  },
+  {
+    "playerId": "martest01",
+    "fullName": "Starling Marte",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 39.44
+  },
+  {
+    "playerId": "santaca01",
+    "fullName": "Carlos Santana",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 39.25
+  },
+  {
+    "playerId": "ordonma01",
+    "fullName": "Magglio Ordonez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 38.79
+  },
+  {
+    "playerId": "gonzaju03",
+    "fullName": "Juan Gonzalez",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": 38.68
+  },
+  {
+    "playerId": "martiru01",
+    "fullName": "Russell Martin",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "East York",
+    "warCareer": 38.66
+  },
+  {
+    "playerId": "davisch01",
+    "fullName": "Chili Davis",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Jamaica",
+    "birthCountryRaw": "Jamaica",
+    "birthCity": "Kingston",
+    "warCareer": 38.36
+  },
+  {
+    "playerId": "ramirha01",
+    "fullName": "Hanley Ramirez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Samana",
+    "warCareer": 38.28
+  },
+  {
+    "playerId": "heathje01",
+    "fullName": "Jeff Heath",
+    "birthYear": 1915,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Fort William",
+    "warCareer": 37.74
+  },
+  {
+    "playerId": "reyesjo01",
+    "fullName": "Jose Reyes",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 36.99
+  },
+  {
+    "playerId": "bautijo02",
+    "fullName": "Jose Bautista",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 36.78
+  },
+  {
+    "playerId": "simmoan01",
+    "fullName": "Andrelton Simmons",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Mundo Nobo",
+    "warCareer": 36.5
+  },
+  {
+    "playerId": "rijojo01",
+    "fullName": "Jose Rijo",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 36.49
+  },
+  {
+    "playerId": "cuetojo01",
+    "fullName": "Johnny Cueto",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 36.3
+  },
+  {
+    "playerId": "perezsa02",
+    "fullName": "Salvador Perez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 35.7
+  },
+  {
+    "playerId": "marteke01",
+    "fullName": "Ketel Marte",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nizao",
+    "warCareer": 35.3
+  },
+  {
+    "playerId": "encared01",
+    "fullName": "Edwin Encarnacion",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 35.26
+  },
+  {
+    "playerId": "choosh01",
+    "fullName": "Shin-Soo Choo",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Busan",
+    "warCareer": 34.68
+  },
+  {
+    "playerId": "andruel01",
+    "fullName": "Elvis Andrus",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 34.53
+  },
+  {
+    "playerId": "guerrpe01",
+    "fullName": "Pedro Guerrero",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 34.45
+  },
+  {
+    "playerId": "fordru01",
+    "fullName": "Russ Ford",
+    "birthYear": 1883,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Brandon",
+    "warCareer": 34.35
+  },
+  {
+    "playerId": "thomsbo01",
+    "fullName": "Bobby Thomson",
+    "birthYear": 1923,
+    "birthDecade": 1920,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Glasgow",
+    "warCareer": 33.78
+  },
+  {
+    "playerId": "darviyu01",
+    "fullName": "Yu Darvish",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Habikino",
+    "warCareer": 33.09
+  },
+  {
+    "playerId": "cartyri01",
+    "fullName": "Rico Carty",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 32.58
+  },
+  {
+    "playerId": "renteed01",
+    "fullName": "Edgar Renteria",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Barranquilla",
+    "warCareer": 32.44
+  },
+  {
+    "playerId": "ramirar01",
+    "fullName": "Aramis Ramirez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 32.34
+  },
+  {
+    "playerId": "quintjo01",
+    "fullName": "Jose Quintana",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Arjona",
+    "warCareer": 31.83
+  },
+  {
+    "playerId": "martivi01",
+    "fullName": "Victor Martinez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": 31.76
+  },
+  {
+    "playerId": "galaran01",
+    "fullName": "Andres Galarraga",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 31.7
+  },
+  {
+    "playerId": "valenjo03",
+    "fullName": "Jose Valentin",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Manati",
+    "warCareer": 31.62
+  },
+  {
+    "playerId": "hillejo01",
+    "fullName": "John Hiller",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 30.47
+  },
+  {
+    "playerId": "higuete01",
+    "fullName": "Teddy Higuera",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": 30.32
+  },
+  {
+    "playerId": "peraljh01",
+    "fullName": "Jhonny Peralta",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 30.29
+  },
+  {
+    "playerId": "cabreas01",
+    "fullName": "Asdrubal Cabrera",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto La Cruz",
+    "warCareer": 30.09
+  },
+  {
+    "playerId": "hernali01",
+    "fullName": "Livan Hernandez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Villa Clara",
+    "warCareer": 29.98
+  },
+  {
+    "playerId": "lopezja01",
+    "fullName": "Javy Lopez",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 29.66
+  },
+  {
+    "playerId": "ozunama01",
+    "fullName": "Marcell Ozuna",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 29.62
+  },
+  {
+    "playerId": "abreujo02",
+    "fullName": "Jose Abreu",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cienfuegos",
+    "warCareer": 29.51
+  },
+  {
+    "playerId": "mondera01",
+    "fullName": "Raul Mondesi",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 29.51
+  },
+  {
+    "playerId": "castilu01",
+    "fullName": "Luis Castillo",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 29.07
+  },
+  {
+    "playerId": "anderjo01",
+    "fullName": "John Anderson",
+    "birthYear": 1873,
+    "birthDecade": 1870,
+    "birthCountry": "Norway",
+    "birthCountryRaw": "Norway",
+    "birthCity": "Sarpsborg",
+    "warCareer": 28.77
+  },
+  {
+    "playerId": "alfoned01",
+    "fullName": "Edgardo Alfonzo",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Santa Teresa del Tuy",
+    "warCareer": 28.76
+  },
+  {
+    "playerId": "valoel01",
+    "fullName": "Elmer Valo",
+    "birthYear": 1921,
+    "birthDecade": 1920,
+    "birthCountry": "Poland",
+    "birthCountryRaw": "Poland",
+    "birthCity": "Rybnik",
+    "warCareer": 28.66
+  },
+  {
+    "playerId": "soriaal01",
+    "fullName": "Alfonso Soriano",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 28.55
+  },
+  {
+    "playerId": "avilabo01",
+    "fullName": "Bobby Avila",
+    "birthYear": 1924,
+    "birthDecade": 1920,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Veracruz",
+    "warCareer": 28.5
+  },
+  {
+    "playerId": "puhlte01",
+    "fullName": "Terry Puhl",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Melville",
+    "warCareer": 28.32
+  },
+  {
+    "playerId": "leeca01",
+    "fullName": "Carlos Lee",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Aguadulce",
+    "warCareer": 28.31
+  },
+  {
+    "playerId": "lezcasi01",
+    "fullName": "Sixto Lezcano",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": 28.27
+  },
+  {
+    "playerId": "morame01",
+    "fullName": "Melvin Mora",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Agua Negra",
+    "warCareer": 28.25
+  },
+  {
+    "playerId": "tovarce01",
+    "fullName": "Cesar Tovar",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 28.25
+  },
+  {
+    "playerId": "sanchan01",
+    "fullName": "Anibal Sanchez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 28.06
+  },
+  {
+    "playerId": "guillca01",
+    "fullName": "Carlos Guillen",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 27.74
+  },
+  {
+    "playerId": "sanguma01",
+    "fullName": "Manny Sanguillen",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 27.61
+  },
+  {
+    "playerId": "pradoma01",
+    "fullName": "Martin Prado",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 27.48
+  },
+  {
+    "playerId": "santibe01",
+    "fullName": "Benito Santiago",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 27.38
+  },
+  {
+    "playerId": "baezja01",
+    "fullName": "Javier Baez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 27.31
+  },
+  {
+    "playerId": "cardele01",
+    "fullName": "Leo Cardenas",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Matanzas",
+    "warCareer": 27.26
+  },
+  {
+    "playerId": "gonzato01",
+    "fullName": "Tony Gonzalez",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Central Cunagua",
+    "warCareer": 27.04
+  },
+  {
+    "playerId": "morneju01",
+    "fullName": "Justin Morneau",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "New Westminster",
+    "warCareer": 27.02
+  },
+  {
+    "playerId": "santaer01",
+    "fullName": "Ervin Santana",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 27.02
+  },
+  {
+    "playerId": "cuellmi01",
+    "fullName": "Mike Cuellar",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Villas",
+    "warCareer": 26.89
+  },
+  {
+    "playerId": "escobyu01",
+    "fullName": "Yunel Escobar",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 26.88
+  },
+  {
+    "playerId": "suareeu01",
+    "fullName": "Eugenio Suarez",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Ordaz",
+    "warCareer": 26.75
+  },
+  {
+    "playerId": "oglivbe01",
+    "fullName": "Ben Oglivie",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 26.38
+  },
+  {
+    "playerId": "segurje01",
+    "fullName": "Jean Segura",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Juan",
+    "warCareer": 26.31
+  },
+  {
+    "playerId": "doyleja01",
+    "fullName": "Jack Doyle",
+    "birthYear": 1869,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Killorgin",
+    "warCareer": 25.88
+  },
+  {
+    "playerId": "martira02",
+    "fullName": "Ramon Martinez",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 25.86
+  },
+  {
+    "playerId": "torricr99",
+    "fullName": "Cristobal Torriente",
+    "birthYear": 1893,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cienfuegos",
+    "warCareer": 25.82
+  },
+  {
+    "playerId": "sotoma01",
+    "fullName": "Mario Soto",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 25.75
+  },
+  {
+    "playerId": "astacpe01",
+    "fullName": "Pedro Astacio",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": 25.63
+  },
+  {
+    "playerId": "penaca01",
+    "fullName": "Carlos Pena",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 25.47
+  },
+  {
+    "playerId": "javiest01",
+    "fullName": "Stan Javier",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 25.46
+  },
+  {
+    "playerId": "lowelmi01",
+    "fullName": "Mike Lowell",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 24.85
+  },
+  {
+    "playerId": "alvarwi01",
+    "fullName": "Wilson Alvarez",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 24.81
+  },
+  {
+    "playerId": "bayja01",
+    "fullName": "Jason Bay",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Trail",
+    "warCareer": 24.74
+  },
+  {
+    "playerId": "penato01",
+    "fullName": "Tony Pena",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": 24.73
+  },
+  {
+    "playerId": "koskico01",
+    "fullName": "Corey Koskie",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Anola",
+    "warCareer": 24.57
+  },
+  {
+    "playerId": "gonzaca01",
+    "fullName": "Carlos Gonzalez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 24.5
+  },
+  {
+    "playerId": "escobke01",
+    "fullName": "Kelvim Escobar",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": 24.41
+  },
+  {
+    "playerId": "gomezca01",
+    "fullName": "Carlos Gomez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 24.32
+  },
+  {
+    "playerId": "guzmaju01",
+    "fullName": "Juan Guzman",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 24.28
+  },
+  {
+    "playerId": "janseke01",
+    "fullName": "Kenley Jansen",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 24.24
+  },
+  {
+    "playerId": "rodrifr03",
+    "fullName": "Francisco Rodriguez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 24.21
+  },
+  {
+    "playerId": "chapmar01",
+    "fullName": "Aroldis Chapman",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Holguin",
+    "warCareer": 24.13
+  },
+  {
+    "playerId": "valdeis01",
+    "fullName": "Ismael Valdez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Victoria",
+    "warCareer": 24.13
+  },
+  {
+    "playerId": "selkige01",
+    "fullName": "George Selkirk",
+    "birthYear": 1908,
+    "birthDecade": 1900,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Huntsville",
+    "warCareer": 23.48
+  },
+  {
+    "playerId": "tartada01",
+    "fullName": "Danny Tartabull",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 23.3
+  },
+  {
+    "playerId": "tayloto02",
+    "fullName": "Tony Taylor",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Central Alava",
+    "warCareer": 23.2
+  },
+  {
+    "playerId": "hernaor01",
+    "fullName": "Orlando Hernandez",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Villa Clara",
+    "warCareer": 23.14
+  },
+  {
+    "playerId": "alouma01",
+    "fullName": "Matty Alou",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 23.07
+  },
+  {
+    "playerId": "aybarer01",
+    "fullName": "Erick Aybar",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 22.82
+  },
+  {
+    "playerId": "austiji01",
+    "fullName": "Jimmy Austin",
+    "birthYear": 1879,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Swansea",
+    "warCareer": 22.81
+  },
+  {
+    "playerId": "loaizes01",
+    "fullName": "Esteban Loaiza",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": 22.73
+  },
+  {
+    "playerId": "uribeju01",
+    "fullName": "Juan Uribe",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Palenque",
+    "warCareer": 22.57
+  },
+  {
+    "playerId": "dihigma99",
+    "fullName": "Martin Dihigo",
+    "birthYear": 1905,
+    "birthDecade": 1900,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Matanzas",
+    "warCareer": 22.53
+  },
+  {
+    "playerId": "ruizca01",
+    "fullName": "Carlos Ruiz",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "David",
+    "warCareer": 22.44
+  },
+  {
+    "playerId": "gallayo01",
+    "fullName": "Yovani Gallardo",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Penjamillo",
+    "warCareer": 22.34
+  },
+  {
+    "playerId": "scutama01",
+    "fullName": "Marco Scutaro",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felipe",
+    "warCareer": 22.07
+  },
+  {
+    "playerId": "hernara02",
+    "fullName": "Ramon Hernandez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 22.06
+  },
+  {
+    "playerId": "ramospe01",
+    "fullName": "Pedro Ramos",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": 21.86
+  },
+  {
+    "playerId": "ramiral03",
+    "fullName": "Alexei Ramirez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": 21.84
+  },
+  {
+    "playerId": "cespeyo01",
+    "fullName": "Yoenis Cespedes",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Campechuela",
+    "warCareer": 21.37
+  },
+  {
+    "playerId": "cabreor01",
+    "fullName": "Orlando Cabrera",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": 21.33
+  },
+  {
+    "playerId": "matsuhi01",
+    "fullName": "Hideki Matsui",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Neagari-cho",
+    "warCareer": 21.23
+  },
+  {
+    "playerId": "carrach01",
+    "fullName": "Chico Carrasquel",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 21.17
+  },
+  {
+    "playerId": "cabreme01",
+    "fullName": "Melky Cabrera",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 21.14
+  },
+  {
+    "playerId": "guilloz01",
+    "fullName": "Ozzie Guillen",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ocumare del Tuy",
+    "warCareer": 21
+  },
+  {
+    "playerId": "nomohi01",
+    "fullName": "Hideo Nomo",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Osaka",
+    "warCareer": 20.94
+  },
+  {
+    "playerId": "kurodhi01",
+    "fullName": "Hiroki Kuroda",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Osaka",
+    "warCareer": 20.88
+  },
+  {
+    "playerId": "cardejo02",
+    "fullName": "Jose Cardenal",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Matanzas",
+    "warCareer": 20.74
+  },
+  {
+    "playerId": "sanchre01",
+    "fullName": "Rey Sanchez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 20.59
+  },
+  {
+    "playerId": "kellyro01",
+    "fullName": "Roberto Kelly",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 20.5
+  },
+  {
+    "playerId": "polanjo01",
+    "fullName": "Jorge Polanco",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 20.47
+  },
+  {
+    "playerId": "keplema01",
+    "fullName": "Max Kepler",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Berlin",
+    "warCareer": 20.45
+  },
+  {
+    "playerId": "jimenub01",
+    "fullName": "Ubaldo Jimenez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": 20.36
+  },
+  {
+    "playerId": "teherju01",
+    "fullName": "Julio Teheran",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": 20.35
+  },
+  {
+    "playerId": "wardpe01",
+    "fullName": "Pete Ward",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": 20.27
+  },
+  {
+    "playerId": "ryuhy01",
+    "fullName": "Hyun-jin Ryu",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Incheon",
+    "warCareer": 20.2
+  },
+  {
+    "playerId": "grandya01",
+    "fullName": "Yasmani Grandal",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 20.17
+  },
+  {
+    "playerId": "bellge02",
+    "fullName": "George Bell",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 20.01
+  },
+  {
+    "playerId": "parkch01",
+    "fullName": "Chan Ho Park",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Kongju",
+    "warCareer": 19.93
+  },
+  {
+    "playerId": "drabomo01",
+    "fullName": "Moe Drabowsky",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Poland",
+    "birthCountryRaw": "Poland",
+    "birthCity": "Ozanna",
+    "warCareer": 19.65
+  },
+  {
+    "playerId": "baergca01",
+    "fullName": "Carlos Baerga",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 19.57
+  },
+  {
+    "playerId": "pizarju01",
+    "fullName": "Juan Pizarro",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 19.57
+  },
+  {
+    "playerId": "cruzjo02",
+    "fullName": "Jose Cruz",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arroyo",
+    "warCareer": 19.56
+  },
+  {
+    "playerId": "castivi02",
+    "fullName": "Vinny Castilla",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Oaxaca",
+    "warCareer": 19.35
+  },
+  {
+    "playerId": "woodge01",
+    "fullName": "George Wood",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Pownal",
+    "warCareer": 19.24
+  },
+  {
+    "playerId": "hubbagl01",
+    "fullName": "Glenn Hubbard",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Hahn",
+    "warCareer": 19.22
+  },
+  {
+    "playerId": "hidalri01",
+    "fullName": "Richard Hidalgo",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 19.17
+  },
+  {
+    "playerId": "chacijh01",
+    "fullName": "Jhoulys Chacin",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 19.09
+  },
+  {
+    "playerId": "rojasmi02",
+    "fullName": "Miguel Rojas",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Los Teques",
+    "warCareer": 19.07
+  },
+  {
+    "playerId": "sandopa01",
+    "fullName": "Pablo Sandoval",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": 19.07
+  },
+  {
+    "playerId": "schoojo01",
+    "fullName": "Jonathan Schoop",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 19.07
+  },
+  {
+    "playerId": "perezpa01",
+    "fullName": "Pascual Perez",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 18.91
+  },
+  {
+    "playerId": "puigya01",
+    "fullName": "Yasiel Puig",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cienfuegos",
+    "warCareer": 18.77
+  },
+  {
+    "playerId": "soriajo01",
+    "fullName": "Joakim Soria",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monclova",
+    "warCareer": 18.62
+  },
+  {
+    "playerId": "dempsry01",
+    "fullName": "Ryan Dempster",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Sechelt",
+    "warCareer": 18.58
+  },
+  {
+    "playerId": "carraca01",
+    "fullName": "Carlos Carrasco",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 18.57
+  },
+  {
+    "playerId": "hernaro01",
+    "fullName": "Roberto Hernandez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 18.51
+  },
+  {
+    "playerId": "lewiste01",
+    "fullName": "Ted Lewis",
+    "birthYear": 1872,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Machynlleth",
+    "warCareer": 18.49
+  },
+  {
+    "playerId": "gomesya01",
+    "fullName": "Yan Gomes",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Brazil",
+    "birthCountryRaw": "Brazil",
+    "birthCity": "Sao Paulo",
+    "warCareer": 18.48
+  },
+  {
+    "playerId": "iglesra01",
+    "fullName": "Raisel Iglesias",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Isla de la Juventud",
+    "warCareer": 18.47
+  },
+  {
+    "playerId": "gutiefr01",
+    "fullName": "Franklin Gutierrez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 18.41
+  },
+  {
+    "playerId": "donovpa01",
+    "fullName": "Patsy Donovan",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Queenstown",
+    "warCareer": 18.39
+  },
+  {
+    "playerId": "castrst01",
+    "fullName": "Starlin Castro",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": 18.21
+  },
+  {
+    "playerId": "rodried05",
+    "fullName": "Eduardo Rodriguez",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 18.11
+  },
+  {
+    "playerId": "liriafr01",
+    "fullName": "Francisco Liriano",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 18.09
+  },
+  {
+    "playerId": "getzich01",
+    "fullName": "Pretzels Getzien",
+    "birthYear": 1864,
+    "birthDecade": 1860,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": 18.04
+  },
+  {
+    "playerId": "benoijo01",
+    "fullName": "Joaquin Benoit",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 17.85
+  },
+  {
+    "playerId": "inciaen01",
+    "fullName": "Ender Inciarte",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 17.85
+  },
+  {
+    "playerId": "paganan01",
+    "fullName": "Angel Pagan",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 17.84
+  },
+  {
+    "playerId": "quantpa01",
+    "fullName": "Paul Quantrill",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 17.8
+  },
+  {
+    "playerId": "harderi01",
+    "fullName": "Rich Harden",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Victoria",
+    "warCareer": 17.72
+  },
+  {
+    "playerId": "millafe01",
+    "fullName": "Felix Millan",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Yabucoa",
+    "warCareer": 17.68
+  },
+  {
+    "playerId": "motama01",
+    "fullName": "Manny Mota",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 17.68
+  },
+  {
+    "playerId": "bedarer01",
+    "fullName": "Erik Bedard",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Navan",
+    "warCareer": 17.42
+  },
+  {
+    "playerId": "vidrojo01",
+    "fullName": "Jose Vidro",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": 17.36
+  },
+  {
+    "playerId": "benitar01",
+    "fullName": "Armando Benitez",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Ramon Santana",
+    "warCareer": 17.33
+  },
+  {
+    "playerId": "gregodi01",
+    "fullName": "Didi Gregorius",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Amsterdam",
+    "warCareer": 17.29
+  },
+  {
+    "playerId": "tanakma01",
+    "fullName": "Masahiro Tanaka",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Itami",
+    "warCareer": 17.25
+  },
+  {
+    "playerId": "offerjo01",
+    "fullName": "Jose Offerman",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 17.12
+  },
+  {
+    "playerId": "infanom01",
+    "fullName": "Omar Infante",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto La Cruz",
+    "warCareer": 17.02
+  },
+  {
+    "playerId": "samueju01",
+    "fullName": "Juan Samuel",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 16.98
+  },
+  {
+    "playerId": "iwakuhi01",
+    "fullName": "Hisashi Iwakuma",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Higashi Yamato",
+    "warCareer": 16.86
+  },
+  {
+    "playerId": "peralda01",
+    "fullName": "David Peralta",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 16.86
+  },
+  {
+    "playerId": "cordefr01",
+    "fullName": "Francisco Cordero",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 16.85
+  },
+  {
+    "playerId": "hernaen02",
+    "fullName": "Enrique Hernandez",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 16.83
+  },
+  {
+    "playerId": "sierrru01",
+    "fullName": "Ruben Sierra",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 16.76
+  },
+  {
+    "playerId": "hernawi01",
+    "fullName": "Willie Hernandez",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aguada",
+    "warCareer": 16.65
+  },
+  {
+    "playerId": "ferriho01",
+    "fullName": "Hobe Ferris",
+    "birthYear": 1874,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Trowbridge",
+    "warCareer": 16.42
+  },
+  {
+    "playerId": "merceor01",
+    "fullName": "Orlando Merced",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Hato Rey",
+    "warCareer": 16.17
+  },
+  {
+    "playerId": "andujjo01",
+    "fullName": "Joaquin Andujar",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 16.13
+  },
+  {
+    "playerId": "figueed01",
+    "fullName": "Ed Figueroa",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ciales",
+    "warCareer": 15.86
+  },
+  {
+    "playerId": "armasto01",
+    "fullName": "Tony Armas",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Piritu",
+    "warCareer": 15.83
+  },
+  {
+    "playerId": "davalvi01",
+    "fullName": "Vic Davalillo",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Churuguara",
+    "warCareer": 15.72
+  },
+  {
+    "playerId": "clarkho01",
+    "fullName": "Horace Clarke",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Frederiksted",
+    "warCareer": 15.67
+  },
+  {
+    "playerId": "lawribr01",
+    "fullName": "Brett Lawrie",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Langley",
+    "warCareer": 15.61
+  },
+  {
+    "playerId": "perezma02",
+    "fullName": "Martin Perez",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guanare",
+    "warCareer": 15.57
+  },
+  {
+    "playerId": "olivaom01",
+    "fullName": "Omar Olivares",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": 15.45
+  },
+  {
+    "playerId": "penaal01",
+    "fullName": "Alejandro Pena",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cambiaso",
+    "warCareer": 15.44
+  },
+  {
+    "playerId": "powervi01",
+    "fullName": "Vic Power",
+    "birthYear": 1927,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": 15.32
+  },
+  {
+    "playerId": "ramoswi01",
+    "fullName": "Wilson Ramos",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 15.26
+  },
+  {
+    "playerId": "doteloc01",
+    "fullName": "Octavio Dotel",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 15.18
+  },
+  {
+    "playerId": "irwinar01",
+    "fullName": "Arthur Irwin",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 15.18
+  },
+  {
+    "playerId": "rodriau01",
+    "fullName": "Aurelio Rodriguez",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Cananea",
+    "warCareer": 15.1
+  },
+  {
+    "playerId": "mcbeaal01",
+    "fullName": "Al McBean",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Charlotte Amalie",
+    "warCareer": 15.05
+  },
+  {
+    "playerId": "deleojo01",
+    "fullName": "Jose DeLeon",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Rancho Viejo",
+    "warCareer": 14.97
+  },
+  {
+    "playerId": "ortajo01",
+    "fullName": "Jorge Orta",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mazatlan",
+    "warCareer": 14.91
+  },
+  {
+    "playerId": "brownto01",
+    "fullName": "Tom Brown",
+    "birthYear": 1860,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Liverpool",
+    "warCareer": 14.81
+  },
+  {
+    "playerId": "gibsoge01",
+    "fullName": "George Gibson",
+    "birthYear": 1880,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 14.72
+  },
+  {
+    "playerId": "gonzama01",
+    "fullName": "Marwin Gonzalez",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Ordaz",
+    "warCareer": 14.48
+  },
+  {
+    "playerId": "severlu01",
+    "fullName": "Luis Severino",
+    "birthYear": 1994,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana de la Mar",
+    "warCareer": 14.43
+  },
+  {
+    "playerId": "floreje01",
+    "fullName": "Jesse Flores",
+    "birthYear": 1914,
+    "birthDecade": 1910,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Guadalajara",
+    "warCareer": 14.35
+  },
+  {
+    "playerId": "mccaski01",
+    "fullName": "Kirk McCaskill",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Kapuskasing",
+    "warCareer": 14.32
+  },
+  {
+    "playerId": "sanchga02",
+    "fullName": "Gary Sanchez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 14.25
+  },
+  {
+    "playerId": "fernajo02",
+    "fullName": "Jose Fernandez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santa Clara",
+    "warCareer": 14.21
+  },
+  {
+    "playerId": "graneja01",
+    "fullName": "Jack Graney",
+    "birthYear": 1886,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. Thomas",
+    "warCareer": 14.21
+  },
+  {
+    "playerId": "montemi01",
+    "fullName": "Miguel Montero",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 14.21
+  },
+  {
+    "playerId": "stairma01",
+    "fullName": "Matt Stairs",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. John",
+    "warCareer": 14.13
+  },
+  {
+    "playerId": "cervefr01",
+    "fullName": "Francisco Cervelli",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 14.12
+  },
+  {
+    "playerId": "betanra01",
+    "fullName": "Rafael Betancourt",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": 14.11
+  },
+  {
+    "playerId": "iglesjo01",
+    "fullName": "Jose Iglesias",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 13.97
+  },
+  {
+    "playerId": "stennre01",
+    "fullName": "Rennie Stennett",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 13.9
+  },
+  {
+    "playerId": "javieju01",
+    "fullName": "Julian Javier",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 13.87
+  },
+  {
+    "playerId": "soriara01",
+    "fullName": "Rafael Soriano",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Jose",
+    "warCareer": 13.79
+  },
+  {
+    "playerId": "batisto01",
+    "fullName": "Tony Batista",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": 13.76
+  },
+  {
+    "playerId": "martica04",
+    "fullName": "Carlos Martinez",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": 13.76
+  },
+  {
+    "playerId": "paxtoja01",
+    "fullName": "James Paxton",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Ladner",
+    "warCareer": 13.75
+  },
+  {
+    "playerId": "gomezru01",
+    "fullName": "Ruben Gomez",
+    "birthYear": 1927,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arroyo",
+    "warCareer": 13.74
+  },
+  {
+    "playerId": "phillad01",
+    "fullName": "Adolfo Phillips",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Bethania",
+    "warCareer": 13.73
+  },
+  {
+    "playerId": "alomasa02",
+    "fullName": "Sandy Alomar",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Salinas",
+    "warCareer": 13.71
+  },
+  {
+    "playerId": "lugoju01",
+    "fullName": "Julio Lugo",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": 13.51
+  },
+  {
+    "playerId": "ueharko01",
+    "fullName": "Koji Uehara",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Neyagawa",
+    "warCareer": 13.51
+  },
+  {
+    "playerId": "cordofr01",
+    "fullName": "Francisco Cordova",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Cerro Azul",
+    "warCareer": 13.4
+  },
+  {
+    "playerId": "rodriel01",
+    "fullName": "Ellie Rodriguez",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": 13.37
+  },
+  {
+    "playerId": "hernajo01",
+    "fullName": "Jose Hernandez",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 13.33
+  },
+  {
+    "playerId": "oquenjo01",
+    "fullName": "Jose Oquendo",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 13.31
+  },
+  {
+    "playerId": "estalbo01",
+    "fullName": "Bobby Estalella",
+    "birthYear": 1911,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cardenas",
+    "warCareer": 13.3
+  },
+  {
+    "playerId": "herreod01",
+    "fullName": "Odubel Herrera",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Jose",
+    "warCareer": 13.29
+  },
+  {
+    "playerId": "bernato01",
+    "fullName": "Tony Bernazard",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": 13.2
+  },
+  {
+    "playerId": "urbinug01",
+    "fullName": "Ugueth Urbina",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 13.18
+  },
+  {
+    "playerId": "moralke01",
+    "fullName": "Kendrys Morales",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Fomento",
+    "warCareer": 13.16
+  },
+  {
+    "playerId": "rodriwa01",
+    "fullName": "Wandy Rodriguez",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago Rodriguez",
+    "warCareer": 13.16
+  },
+  {
+    "playerId": "contrjo01",
+    "fullName": "Jose Contreras",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Martinas",
+    "warCareer": 13.14
+  },
+  {
+    "playerId": "smithpo01",
+    "fullName": "Pop Smith",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Digby",
+    "warCareer": 13.07
+  },
+  {
+    "playerId": "geronce01",
+    "fullName": "Cesar Geronimo",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": 12.94
+  },
+  {
+    "playerId": "penaor01",
+    "fullName": "Orlando Pena",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Victoria de las Tunas",
+    "warCareer": 12.9
+  },
+  {
+    "playerId": "verasqu01",
+    "fullName": "Quilvio Veras",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 12.88
+  },
+  {
+    "playerId": "guzmajo01",
+    "fullName": "Jose Guzman",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santa Isabel",
+    "warCareer": 12.87
+  },
+  {
+    "playerId": "mcleala01",
+    "fullName": "Larry McLean",
+    "birthYear": 1881,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Fredericton",
+    "warCareer": 12.84
+  },
+  {
+    "playerId": "pineijo01",
+    "fullName": "Joel Pineiro",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 12.72
+  },
+  {
+    "playerId": "lopezhe01",
+    "fullName": "Hector Lopez",
+    "birthYear": 1929,
+    "birthDecade": 1920,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 12.71
+  },
+  {
+    "playerId": "hernace02",
+    "fullName": "Cesar Hernandez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 12.64
+  },
+  {
+    "playerId": "batismi01",
+    "fullName": "Miguel Batista",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 12.63
+  },
+  {
+    "playerId": "guzmacr01",
+    "fullName": "Cristian Guzman",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 12.63
+  },
+  {
+    "playerId": "chiriro01",
+    "fullName": "Robinson Chirinos",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Punto Fijo",
+    "warCareer": 12.62
+  },
+  {
+    "playerId": "versazo01",
+    "fullName": "Zoilo Versalles",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 12.58
+  },
+  {
+    "playerId": "seguidi01",
+    "fullName": "Diego Segui",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Holguin",
+    "warCareer": 12.55
+  },
+  {
+    "playerId": "wangch01",
+    "fullName": "Chien-Ming Wang",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Tainan City",
+    "warCareer": 12.52
+  },
+  {
+    "playerId": "phillbi01",
+    "fullName": "Bill Phillips",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. John",
+    "warCareer": 12.49
+  },
+  {
+    "playerId": "escobed01",
+    "fullName": "Eduardo Escobar",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Villa de Cura",
+    "warCareer": 12.43
+  },
+  {
+    "playerId": "villajo01",
+    "fullName": "Jonathan Villar",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Vega",
+    "warCareer": 12.41
+  },
+  {
+    "playerId": "pinedmi01",
+    "fullName": "Michael Pineda",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Yaguate",
+    "warCareer": 12.32
+  },
+  {
+    "playerId": "castiwe01",
+    "fullName": "Welington Castillo",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Isidro",
+    "warCareer": 12.07
+  },
+  {
+    "playerId": "estrama01",
+    "fullName": "Marco Estrada",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Sonora",
+    "warCareer": 12.05
+  },
+  {
+    "playerId": "alicelu01",
+    "fullName": "Luis Alicea",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 11.95
+  },
+  {
+    "playerId": "reynoar02",
+    "fullName": "Armando Reynoso",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Luis Potosi",
+    "warCareer": 11.95
+  },
+  {
+    "playerId": "brownje01",
+    "fullName": "Jerry Browne",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Christiansted",
+    "warCareer": 11.94
+  },
+  {
+    "playerId": "caldeiv01",
+    "fullName": "Ivan Calderon",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": 11.93
+  },
+  {
+    "playerId": "sotoge01",
+    "fullName": "Geovany Soto",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 11.92
+  },
+  {
+    "playerId": "rosengo01",
+    "fullName": "Goody Rosen",
+    "birthYear": 1912,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 11.85
+  },
+  {
+    "playerId": "desseel01",
+    "fullName": "Elmer Dessens",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Hermosillo",
+    "warCareer": 11.8
+  },
+  {
+    "playerId": "consusa01",
+    "fullName": "Sandy Consuegra",
+    "birthYear": 1920,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Potrerillos",
+    "warCareer": 11.75
+  },
+  {
+    "playerId": "fuentti01",
+    "fullName": "Tito Fuentes",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 11.75
+  },
+  {
+    "playerId": "gagneer01",
+    "fullName": "Eric Gagne",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": 11.74
+  },
+  {
+    "playerId": "mendora01",
+    "fullName": "Ramiro Mendoza",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Los Santos",
+    "warCareer": 11.72
+  },
+  {
+    "playerId": "brainda01",
+    "fullName": "Dave Brain",
+    "birthYear": 1879,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Hereford",
+    "warCareer": 11.59
+  },
+  {
+    "playerId": "hasegsh01",
+    "fullName": "Shigetoshi Hasegawa",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kobe",
+    "warCareer": 11.56
+  },
+  {
+    "playerId": "novaiv01",
+    "fullName": "Ivan Nova",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Palenque",
+    "warCareer": 11.48
+  },
+  {
+    "playerId": "valvejo01",
+    "fullName": "Jose Valverde",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 11.48
+  },
+  {
+    "playerId": "diazbo01",
+    "fullName": "Bo Diaz",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cua",
+    "warCareer": 11.47
+  },
+  {
+    "playerId": "crainje01",
+    "fullName": "Jesse Crain",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 11.4
+  },
+  {
+    "playerId": "mesajo01",
+    "fullName": "Jose Mesa",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Pueblo Viejo",
+    "warCareer": 11.39
+  },
+  {
+    "playerId": "padilvi01",
+    "fullName": "Vicente Padilla",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Chinandega",
+    "warCareer": 11.39
+  },
+  {
+    "playerId": "martile01",
+    "fullName": "Leonys Martin",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Villa Clara",
+    "warCareer": 11.34
+  },
+  {
+    "playerId": "izturma01",
+    "fullName": "Maicer Izturis",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 11.33
+  },
+  {
+    "playerId": "ohkato01",
+    "fullName": "Tomo Ohka",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kyoto",
+    "warCareer": 11.28
+  },
+  {
+    "playerId": "trillma01",
+    "fullName": "Manny Trillo",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caripito",
+    "warCareer": 11.27
+  },
+  {
+    "playerId": "perezme01",
+    "fullName": "Melido Perez",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 11.19
+  },
+  {
+    "playerId": "ponsosi01",
+    "fullName": "Sidney Ponson",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Aruba",
+    "birthCountryRaw": "Aruba",
+    "birthCity": "Noord",
+    "warCareer": 11.11
+  },
+  {
+    "playerId": "rosared01",
+    "fullName": "Eddie Rosario",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guayama",
+    "warCareer": 11.11
+  },
+  {
+    "playerId": "dejesiv01",
+    "fullName": "Ivan de Jesus",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 11.1
+  },
+  {
+    "playerId": "martica01",
+    "fullName": "Carmelo Martinez",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Dorado",
+    "warCareer": 11.02
+  },
+  {
+    "playerId": "lagarju01",
+    "fullName": "Juan Lagares",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Constanza",
+    "warCareer": 11
+  },
+  {
+    "playerId": "parrage01",
+    "fullName": "Gerardo Parra",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Santa Barbara",
+    "warCareer": 10.73
+  },
+  {
+    "playerId": "molinbe01",
+    "fullName": "Bengie Molina",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 10.69
+  },
+  {
+    "playerId": "garcija02",
+    "fullName": "Jaime Garcia",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Reynosa",
+    "warCareer": 10.68
+  },
+  {
+    "playerId": "perezol01",
+    "fullName": "Oliver Perez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Culiacan",
+    "warCareer": 10.64
+  },
+  {
+    "playerId": "kimby01",
+    "fullName": "Byung-Hyun Kim",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Kwangju",
+    "warCareer": 10.59
+  },
+  {
+    "playerId": "leallu01",
+    "fullName": "Luis Leal",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 10.56
+  },
+  {
+    "playerId": "nilssda01",
+    "fullName": "Dave Nilsson",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Brisbane",
+    "warCareer": 10.55
+  },
+  {
+    "playerId": "alomasa01",
+    "fullName": "Sandy Alomar",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Salinas",
+    "warCareer": 10.53
+  },
+  {
+    "playerId": "chenbr01",
+    "fullName": "Bruce Chen",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 10.51
+  },
+  {
+    "playerId": "saitota01",
+    "fullName": "Takashi Saito",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Sendai",
+    "warCareer": 10.5
+  },
+  {
+    "playerId": "hallge01",
+    "fullName": "George Hall",
+    "birthYear": 1849,
+    "birthDecade": 1840,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Stepney",
+    "warCareer": 10.47
+  },
+  {
+    "playerId": "jurrjja01",
+    "fullName": "Jair Jurrjens",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Santa Maria",
+    "warCareer": 10.42
+  },
+  {
+    "playerId": "aokino01",
+    "fullName": "Nori Aoki",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Hyuga",
+    "warCareer": 10.39
+  },
+  {
+    "playerId": "aquinlu01",
+    "fullName": "Luis Aquino",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 10.31
+  },
+  {
+    "playerId": "archeji01",
+    "fullName": "Jimmy Archer",
+    "birthYear": 1883,
+    "birthDecade": 1880,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Dublin",
+    "warCareer": 10.23
+  },
+  {
+    "playerId": "marteda01",
+    "fullName": "Damaso Marte",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 10.18
+  },
+  {
+    "playerId": "escobal02",
+    "fullName": "Alcides Escobar",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Sabana",
+    "warCareer": 10.15
+  },
+  {
+    "playerId": "gonzami03",
+    "fullName": "Miguel Gonzalez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Guadalajara",
+    "warCareer": 10.15
+  },
+  {
+    "playerId": "herreke01",
+    "fullName": "Kelvin Herrera",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Tenares",
+    "warCareer": 10.12
+  },
+  {
+    "playerId": "masteju01",
+    "fullName": "Justin Masterson",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Jamaica",
+    "birthCountryRaw": "Jamaica",
+    "birthCity": "Kingston",
+    "warCareer": 10.05
+  },
+  {
+    "playerId": "lopezjo01",
+    "fullName": "Jose Lopez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": 10.02
+  },
+  {
+    "playerId": "gomezle02",
+    "fullName": "Leo Gomez",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Canovanas",
+    "warCareer": 9.95
+  },
+  {
+    "playerId": "maldoca01",
+    "fullName": "Candy Maldonado",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": 9.94
+  },
+  {
+    "playerId": "beniqju01",
+    "fullName": "Juan Beniquez",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Sebastian",
+    "warCareer": 9.93
+  },
+  {
+    "playerId": "berenju01",
+    "fullName": "Juan Berenguer",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Aguadulce",
+    "warCareer": 9.92
+  },
+  {
+    "playerId": "velezot01",
+    "fullName": "Otto Velez",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 9.87
+  },
+  {
+    "playerId": "marmoca01",
+    "fullName": "Carlos Marmol",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 9.78
+  },
+  {
+    "playerId": "leema02",
+    "fullName": "Manuel Lee",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 9.73
+  },
+  {
+    "playerId": "francje01",
+    "fullName": "Jeff Francis",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": 9.63
+  },
+  {
+    "playerId": "marchph01",
+    "fullName": "Phil Marchildon",
+    "birthYear": 1913,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Penetanguishene",
+    "warCareer": 9.62
+  },
+  {
+    "playerId": "morenom01",
+    "fullName": "Omar Moreno",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Puerto Armuelles",
+    "warCareer": 9.59
+  },
+  {
+    "playerId": "callaal01",
+    "fullName": "Alberto Callaspo",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 9.58
+  },
+  {
+    "playerId": "profaju01",
+    "fullName": "Jurickson Profar",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 9.51
+  },
+  {
+    "playerId": "cormirh01",
+    "fullName": "Rheal Cormier",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Moncton",
+    "warCareer": 9.47
+  },
+  {
+    "playerId": "gonzami01",
+    "fullName": "Mike Gonzalez",
+    "birthYear": 1890,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 9.41
+  },
+  {
+    "playerId": "matsuda01",
+    "fullName": "Daisuke Matsuzaka",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": 9.39
+  },
+  {
+    "playerId": "nerishe01",
+    "fullName": "Hector Neris",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Altagracia",
+    "warCareer": 9.39
+  },
+  {
+    "playerId": "gonzaal02",
+    "fullName": "Alex Gonzalez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cagua",
+    "warCareer": 9.38
+  },
+  {
+    "playerId": "arrojro01",
+    "fullName": "Rolando Arrojo",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santa Clara",
+    "warCareer": 9.37
+  },
+  {
+    "playerId": "garciav01",
+    "fullName": "Avisail Garcia",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Anaco",
+    "warCareer": 9.37
+  },
+  {
+    "playerId": "navarja01",
+    "fullName": "Jaime Navarro",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 9.33
+  },
+  {
+    "playerId": "ogandal01",
+    "fullName": "Alexi Ogando",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 9.33
+  },
+  {
+    "playerId": "galvifr01",
+    "fullName": "Freddy Galvis",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Punto Fijo",
+    "warCareer": 9.3
+  },
+  {
+    "playerId": "lopezau01",
+    "fullName": "Aurelio Lopez",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tecamachalco",
+    "warCareer": 9.29
+  },
+  {
+    "playerId": "coxda01",
+    "fullName": "Danny Cox",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Northampton",
+    "warCareer": 9.28
+  },
+  {
+    "playerId": "rojasco01",
+    "fullName": "Cookie Rojas",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 9.28
+  },
+  {
+    "playerId": "florewi01",
+    "fullName": "Wilmer Flores",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 9.25
+  },
+  {
+    "playerId": "salazda01",
+    "fullName": "Danny Salazar",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 9.25
+  },
+  {
+    "playerId": "riverju01",
+    "fullName": "Juan Rivera",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guarenas",
+    "warCareer": 9.22
+  },
+  {
+    "playerId": "balfogr01",
+    "fullName": "Grant Balfour",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": 9.19
+  },
+  {
+    "playerId": "carrahe01",
+    "fullName": "Hector Carrasco",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 9.18
+  },
+  {
+    "playerId": "garcija01",
+    "fullName": "Santiago Casilla",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 9.16
+  },
+  {
+    "playerId": "clarkni01",
+    "fullName": "Nig Clarke",
+    "birthYear": 1882,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Amherstburg",
+    "warCareer": 9.14
+  },
+  {
+    "playerId": "durazer01",
+    "fullName": "Erubiel Durazo",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Hermosillo",
+    "warCareer": 9.11
+  },
+  {
+    "playerId": "roberda07",
+    "fullName": "Dave Roberts",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Naha",
+    "warCareer": 9.05
+  },
+  {
+    "playerId": "sosael01",
+    "fullName": "Elias Sosa",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Vega",
+    "warCareer": 9.05
+  },
+  {
+    "playerId": "salazlu01",
+    "fullName": "Luis Salazar",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": 9.01
+  },
+  {
+    "playerId": "hendrli01",
+    "fullName": "Liam Hendriks",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Perth",
+    "warCareer": 9
+  },
+  {
+    "playerId": "polonlu01",
+    "fullName": "Luis Polonia",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 9
+  },
+  {
+    "playerId": "virgioz02",
+    "fullName": "Ozzie Virgil",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": 8.99
+  },
+  {
+    "playerId": "leffecr01",
+    "fullName": "Craig Lefferts",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Munich",
+    "warCareer": 8.91
+  },
+  {
+    "playerId": "perezod01",
+    "fullName": "Odalis Perez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": 8.91
+  },
+  {
+    "playerId": "dailyhu01",
+    "fullName": "Hugh Daily",
+    "birthYear": 1847,
+    "birthDecade": 1840,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 8.9
+  },
+  {
+    "playerId": "clevere01",
+    "fullName": "Reggie Cleveland",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Swift Current",
+    "warCareer": 8.88
+  },
+  {
+    "playerId": "jacksed01",
+    "fullName": "Edwin Jackson",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Neu-Ulm",
+    "warCareer": 8.85
+  },
+  {
+    "playerId": "romovi01",
+    "fullName": "Vicente Romo",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Santa Rosalia",
+    "warCareer": 8.85
+  },
+  {
+    "playerId": "stroppe01",
+    "fullName": "Pedro Strop",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 8.8
+  },
+  {
+    "playerId": "uribejo01",
+    "fullName": "Jose Uribe",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 8.72
+  },
+  {
+    "playerId": "urshegi01",
+    "fullName": "Giovanny Urshela",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": 8.68
+  },
+  {
+    "playerId": "daalom01",
+    "fullName": "Omar Daal",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 8.65
+  },
+  {
+    "playerId": "encarju01",
+    "fullName": "Juan Encarnacion",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": 8.65
+  },
+  {
+    "playerId": "benarma01",
+    "fullName": "Marvin Benard",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Bluefields",
+    "warCareer": 8.61
+  },
+  {
+    "playerId": "osunaro01",
+    "fullName": "Roberto Osuna",
+    "birthYear": 1995,
+    "birthDecade": 1990,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Juan Jose Rios",
+    "warCareer": 8.61
+  },
+  {
+    "playerId": "marreco01",
+    "fullName": "Connie Marrero",
+    "birthYear": 1911,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Sagua La Grande",
+    "warCareer": 8.6
+  },
+  {
+    "playerId": "petityu01",
+    "fullName": "Yusmeiro Petit",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 8.59
+  },
+  {
+    "playerId": "alonsyo01",
+    "fullName": "Yonder Alonso",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 8.58
+  },
+  {
+    "playerId": "azcuejo01",
+    "fullName": "Joe Azcue",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cienfuegos",
+    "warCareer": 8.58
+  },
+  {
+    "playerId": "rodrife01",
+    "fullName": "Felix Rodriguez",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": 8.54
+  },
+  {
+    "playerId": "silvaca01",
+    "fullName": "Carlos Silva",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": 8.54
+  },
+  {
+    "playerId": "mongesi01",
+    "fullName": "Sid Monge",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Agua Prieta",
+    "warCareer": 8.53
+  },
+  {
+    "playerId": "alvarhe01",
+    "fullName": "Henderson Alvarez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 8.5
+  },
+  {
+    "playerId": "barrifr01",
+    "fullName": "Francisco Barrios",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Hermosillo",
+    "warCareer": 8.38
+  },
+  {
+    "playerId": "valbulu01",
+    "fullName": "Luis Valbuena",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caja Seca",
+    "warCareer": 8.35
+  },
+  {
+    "playerId": "riverfe01",
+    "fullName": "Felipe Rivero",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felipe",
+    "warCareer": 8.26
+  },
+  {
+    "playerId": "chenwe02",
+    "fullName": "Wei-Yin Chen",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Kaohsiung City",
+    "warCareer": 8.24
+  },
+  {
+    "playerId": "ulricdu01",
+    "fullName": "Dutch Ulrich",
+    "birthYear": 1899,
+    "birthDecade": 1890,
+    "birthCountry": "Austria",
+    "birthCountryRaw": "Austria",
+    "birthCity": null,
+    "warCareer": 8.14
+  },
+  {
+    "playerId": "ayalalu01",
+    "fullName": "Luis Ayala",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": 8.1
+  },
+  {
+    "playerId": "solaito01",
+    "fullName": "Tony Solaita",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "American Samoa",
+    "birthCountryRaw": "American Samoa",
+    "birthCity": "Nuuuli",
+    "warCareer": 8.04
+  },
+  {
+    "playerId": "juddos01",
+    "fullName": "Oscar Judd",
+    "birthYear": 1908,
+    "birthDecade": 1900,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 8.02
+  },
+  {
+    "playerId": "lopezja02",
+    "fullName": "Javier Lopez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 8.02
+  },
+  {
+    "playerId": "sanomi01",
+    "fullName": "Miguel Sano",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 8.02
+  },
+  {
+    "playerId": "olivomi01",
+    "fullName": "Miguel Olivo",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Vasquez",
+    "warCareer": 7.98
+  },
+  {
+    "playerId": "corajo01",
+    "fullName": "Joey Cora",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": 7.94
+  },
+  {
+    "playerId": "trevial01",
+    "fullName": "Alex Trevino",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monterrey",
+    "warCareer": 7.93
+  },
+  {
+    "playerId": "hessot01",
+    "fullName": "Otto Hess",
+    "birthYear": 1878,
+    "birthDecade": 1870,
+    "birthCountry": "Switzerland",
+    "birthCountryRaw": "Switzerland",
+    "birthCity": "Berne",
+    "warCareer": 7.86
+  },
+  {
+    "playerId": "perezro02",
+    "fullName": "Roberto Perez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": 7.84
+  },
+  {
+    "playerId": "ventuyo01",
+    "fullName": "Yordano Ventura",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Samana",
+    "warCareer": 7.73
+  },
+  {
+    "playerId": "cairomi01",
+    "fullName": "Miguel Cairo",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Anaco",
+    "warCareer": 7.67
+  },
+  {
+    "playerId": "solando01",
+    "fullName": "Donovan Solano",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Barranquilla",
+    "warCareer": 7.59
+  },
+  {
+    "playerId": "lopezfe01",
+    "fullName": "Felipe Lopez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 7.53
+  },
+  {
+    "playerId": "zimmeje02",
+    "fullName": "Jeff Zimmerman",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Kelowna",
+    "warCareer": 7.53
+  },
+  {
+    "playerId": "fowledi01",
+    "fullName": "Dick Fowler",
+    "birthYear": 1921,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 7.5
+  },
+  {
+    "playerId": "hendrel01",
+    "fullName": "Elrod Hendricks",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Charlotte Amalie",
+    "warCareer": 7.46
+  },
+  {
+    "playerId": "rodnefe01",
+    "fullName": "Fernando Rodney",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 7.46
+  },
+  {
+    "playerId": "leach01",
+    "fullName": "Charlie Lea",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": "Orleans",
+    "warCareer": 7.42
+  },
+  {
+    "playerId": "cruzde01",
+    "fullName": "Deivi Cruz",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 7.4
+  },
+  {
+    "playerId": "berroge01",
+    "fullName": "Geronimo Berroa",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 7.38
+  },
+  {
+    "playerId": "amorosa01",
+    "fullName": "Sandy Amoros",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 7.35
+  },
+  {
+    "playerId": "santira01",
+    "fullName": "Ramon Santiago",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": 7.35
+  },
+  {
+    "playerId": "felizne01",
+    "fullName": "Neftali Feliz",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": 7.33
+  },
+  {
+    "playerId": "blancgr01",
+    "fullName": "Gregor Blanco",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 7.31
+  },
+  {
+    "playerId": "fornimi01",
+    "fullName": "Mike Fornieles",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 7.26
+  },
+  {
+    "playerId": "garcida01",
+    "fullName": "Damaso Garcia",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Moca",
+    "warCareer": 7.23
+  },
+  {
+    "playerId": "rincori01",
+    "fullName": "Ricardo Rincon",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Cuitlahuac",
+    "warCareer": 7.23
+  },
+  {
+    "playerId": "deazaal01",
+    "fullName": "Alejandro De Aza",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guaymate",
+    "warCareer": 7.21
+  },
+  {
+    "playerId": "scantpa01",
+    "fullName": "Pat Scantlebury",
+    "birthYear": 1917,
+    "birthDecade": 1910,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Gatun",
+    "warCareer": 7.14
+  },
+  {
+    "playerId": "mendejo99",
+    "fullName": "Jose Mendez",
+    "birthYear": 1885,
+    "birthDecade": 1880,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cardenas",
+    "warCareer": 7.13
+  },
+  {
+    "playerId": "moretro01",
+    "fullName": "Roger Moret",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guayama",
+    "warCareer": 7.13
+  },
+  {
+    "playerId": "kuehnbi01",
+    "fullName": "Bill Kuehne",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Leipzig",
+    "warCareer": 7.1
+  },
+  {
+    "playerId": "vizcajo01",
+    "fullName": "Jose Vizcaino",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 7.01
+  },
+  {
+    "playerId": "navardi01",
+    "fullName": "Dioner Navarro",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 6.99
+  },
+  {
+    "playerId": "coraal01",
+    "fullName": "Alex Cora",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": 6.96
+  },
+  {
+    "playerId": "bonesri01",
+    "fullName": "Ricky Bones",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Salinas",
+    "warCareer": 6.93
+  },
+  {
+    "playerId": "highadi01",
+    "fullName": "Dick Higham",
+    "birthYear": 1851,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Ipswich",
+    "warCareer": 6.92
+  },
+  {
+    "playerId": "armasto02",
+    "fullName": "Tony Armas",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Piritu",
+    "warCareer": 6.86
+  },
+  {
+    "playerId": "okajihi01",
+    "fullName": "Hideki Okajima",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kyoto",
+    "warCareer": 6.83
+  },
+  {
+    "playerId": "yoshima01",
+    "fullName": "Masato Yoshii",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Arita-gun",
+    "warCareer": 6.71
+  },
+  {
+    "playerId": "solarya01",
+    "fullName": "Yangervis Solarte",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 6.67
+  },
+  {
+    "playerId": "cruzvi01",
+    "fullName": "Victor Cruz",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Rancho Viejo",
+    "warCareer": 6.66
+  },
+  {
+    "playerId": "lelivja01",
+    "fullName": "Jack Lelivelt",
+    "birthYear": 1885,
+    "birthDecade": 1880,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": null,
+    "warCareer": 6.62
+  },
+  {
+    "playerId": "leonaan01",
+    "fullName": "Andy Leonard",
+    "birthYear": 1846,
+    "birthDecade": 1840,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 6.6
+  },
+  {
+    "playerId": "otsukak01",
+    "fullName": "Akinori Otsuka",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Chiba",
+    "warCareer": 6.6
+  },
+  {
+    "playerId": "romoen01",
+    "fullName": "Enrique Romo",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Santa Rosalia",
+    "warCareer": 6.6
+  },
+  {
+    "playerId": "ramirra02",
+    "fullName": "Ramon Ramirez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 6.58
+  },
+  {
+    "playerId": "mantife01",
+    "fullName": "Felix Mantilla",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Isabella",
+    "warCareer": 6.55
+  },
+  {
+    "playerId": "sanchca01",
+    "fullName": "Carlos Sanchez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 6.52
+  },
+  {
+    "playerId": "solerjo01",
+    "fullName": "Jorge Soler",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 6.52
+  },
+  {
+    "playerId": "vazquch01",
+    "fullName": "Christian Vazquez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 6.5
+  },
+  {
+    "playerId": "josefe01",
+    "fullName": "Felix Jose",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 6.38
+  },
+  {
+    "playerId": "odorro01",
+    "fullName": "Rougned Odor",
+    "birthYear": 1994,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 6.38
+  },
+  {
+    "playerId": "mackre01",
+    "fullName": "Reddy Mack",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 6.36
+  },
+  {
+    "playerId": "iguchta01",
+    "fullName": "Tadahito Iguchi",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tanashi",
+    "warCareer": 6.35
+  },
+  {
+    "playerId": "guilljo01",
+    "fullName": "Jose Guillen",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 6.34
+  },
+  {
+    "playerId": "penage01",
+    "fullName": "Geronimo Pena",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Los Alcarrizos",
+    "warCareer": 6.34
+  },
+  {
+    "playerId": "tatisfe01",
+    "fullName": "Fernando Tatis",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 6.34
+  },
+  {
+    "playerId": "castito02",
+    "fullName": "Tony Castillo",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Quibor",
+    "warCareer": 6.33
+  },
+  {
+    "playerId": "pinama01",
+    "fullName": "Manny Pina",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 6.33
+  },
+  {
+    "playerId": "willial03",
+    "fullName": "Albert Williams",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Pearl Lagoon",
+    "warCareer": 6.31
+  },
+  {
+    "playerId": "claudal01",
+    "fullName": "Alex Claudio",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 6.3
+  },
+  {
+    "playerId": "rojasme01",
+    "fullName": "Mel Rojas",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 6.29
+  },
+  {
+    "playerId": "rodgean01",
+    "fullName": "Andre Rodgers",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Bahamas",
+    "birthCountryRaw": "Bahamas",
+    "birthCity": "Nassau",
+    "warCareer": 6.28
+  },
+  {
+    "playerId": "ainsmed01",
+    "fullName": "Eddie Ainsmith",
+    "birthYear": 1890,
+    "birthDecade": 1890,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": null,
+    "warCareer": 6.22
+  },
+  {
+    "playerId": "calerki01",
+    "fullName": "Kiko Calero",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 6.22
+  },
+  {
+    "playerId": "pichahi01",
+    "fullName": "Hipolito Pichardo",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Esperanza",
+    "warCareer": 6.21
+  },
+  {
+    "playerId": "hernara01",
+    "fullName": "Ramon Hernandez",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Carolina",
+    "warCareer": 6.18
+  },
+  {
+    "playerId": "perezca01",
+    "fullName": "Carlos Perez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nigua",
+    "warCareer": 6.18
+  },
+  {
+    "playerId": "familje01",
+    "fullName": "Jeurys Familia",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 6.14
+  },
+  {
+    "playerId": "osunaan01",
+    "fullName": "Antonio Osuna",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Guasave",
+    "warCareer": 6.14
+  },
+  {
+    "playerId": "izturce01",
+    "fullName": "Cesar Izturis",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 6.13
+  },
+  {
+    "playerId": "seoja01",
+    "fullName": "Jae Weong Seo",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Kwangju",
+    "warCareer": 6.12
+  },
+  {
+    "playerId": "maldoma01",
+    "fullName": "Martin Maldonado",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Naguabo",
+    "warCareer": 6.11
+  },
+  {
+    "playerId": "carraal01",
+    "fullName": "Alex Carrasquel",
+    "birthYear": 1912,
+    "birthDecade": 1910,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 6.09
+  },
+  {
+    "playerId": "castrbi01",
+    "fullName": "Bill Castro",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 6.09
+  },
+  {
+    "playerId": "villaca01",
+    "fullName": "Carlos Villanueva",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 6.09
+  },
+  {
+    "playerId": "guantce01",
+    "fullName": "Cecilio Guante",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": 6.07
+  },
+  {
+    "playerId": "ramirra01",
+    "fullName": "Rafael Ramirez",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 6.04
+  },
+  {
+    "playerId": "reyesal01",
+    "fullName": "Alberto Reyes",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 6.04
+  },
+  {
+    "playerId": "youngge02",
+    "fullName": "Gerald Young",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Honduras",
+    "birthCountryRaw": "Honduras",
+    "birthCity": "Tele",
+    "warCareer": 6.02
+  },
+  {
+    "playerId": "felixju01",
+    "fullName": "Junior Felix",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Laguna Salada",
+    "warCareer": 6
+  },
+  {
+    "playerId": "cordewi01",
+    "fullName": "Wil Cordero",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": 5.95
+  },
+  {
+    "playerId": "moylape01",
+    "fullName": "Peter Moylan",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Attadale",
+    "warCareer": 5.95
+  },
+  {
+    "playerId": "kangju01",
+    "fullName": "Jung Ho Kang",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Gwangju",
+    "warCareer": 5.89
+  },
+  {
+    "playerId": "volqued01",
+    "fullName": "Edinson Volquez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 5.88
+  },
+  {
+    "playerId": "motagu01",
+    "fullName": "Guillermo Mota",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 5.87
+  },
+  {
+    "playerId": "saundmi01",
+    "fullName": "Michael Saunders",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Victoria",
+    "warCareer": 5.86
+  },
+  {
+    "playerId": "baezda01",
+    "fullName": "Danys Baez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": 5.78
+  },
+  {
+    "playerId": "walshji02",
+    "fullName": "Jimmy Walsh",
+    "birthYear": 1887,
+    "birthDecade": 1880,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Rathroe",
+    "warCareer": 5.78
+  },
+  {
+    "playerId": "duncama01",
+    "fullName": "Mariano Duncan",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 5.76
+  },
+  {
+    "playerId": "felicpe01",
+    "fullName": "Pedro Feliciano",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 5.74
+  },
+  {
+    "playerId": "colomal01",
+    "fullName": "Alex Colome",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 5.73
+  },
+  {
+    "playerId": "paganjo01",
+    "fullName": "Jose Pagan",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Barceloneta",
+    "warCareer": 5.73
+  },
+  {
+    "playerId": "reyesde01",
+    "fullName": "Dennys Reyes",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Higuera de Zaragoza",
+    "warCareer": 5.66
+  },
+  {
+    "playerId": "riverru01",
+    "fullName": "Ruben Rivera",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Chorrera",
+    "warCareer": 5.64
+  },
+  {
+    "playerId": "acostcy01",
+    "fullName": "Cy Acosta",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "El Sabino",
+    "warCareer": 5.62
+  },
+  {
+    "playerId": "torresa01",
+    "fullName": "Salomon Torres",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 5.62
+  },
+  {
+    "playerId": "emslibo01",
+    "fullName": "Bob Emslie",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Guelph",
+    "warCareer": 5.58
+  },
+  {
+    "playerId": "felizpe01",
+    "fullName": "Pedro Feliz",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": 5.58
+  },
+  {
+    "playerId": "graveda01",
+    "fullName": "Danny Graves",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Viet Nam",
+    "birthCountryRaw": "Viet Nam",
+    "birthCity": "Saigon",
+    "warCareer": 5.57
+  },
+  {
+    "playerId": "congabu01",
+    "fullName": "Bunk Congalton",
+    "birthYear": 1875,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Guelph",
+    "warCareer": 5.51
+  },
+  {
+    "playerId": "wilsoal01",
+    "fullName": "Alex Wilson",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Saudi Arabia",
+    "birthCountryRaw": "Saudi Arabia",
+    "birthCity": "Dhahran",
+    "warCareer": 5.44
+  },
+  {
+    "playerId": "torreyo01",
+    "fullName": "Yorvit Torrealba",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 5.43
+  },
+  {
+    "playerId": "diazel01",
+    "fullName": "Elias Diaz",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 5.38
+  },
+  {
+    "playerId": "pauliro01",
+    "fullName": "Ronny Paulino",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 5.35
+  },
+  {
+    "playerId": "johjike01",
+    "fullName": "Kenji Johjima",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Sasebo",
+    "warCareer": 5.34
+  },
+  {
+    "playerId": "rodried01",
+    "fullName": "Eduardo Rodriguez",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Barceloneta",
+    "warCareer": 5.32
+  },
+  {
+    "playerId": "matsuka01",
+    "fullName": "Kazuo Matsui",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Higashi-Osaka",
+    "warCareer": 5.31
+  },
+  {
+    "playerId": "saenzol01",
+    "fullName": "Olmedo Saenz",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Chitre",
+    "warCareer": 5.28
+  },
+  {
+    "playerId": "borbope01",
+    "fullName": "Pedro Borbon",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Mao",
+    "warCareer": 5.23
+  },
+  {
+    "playerId": "lloydgr01",
+    "fullName": "Graeme Lloyd",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Geelong",
+    "warCareer": 5.23
+  },
+  {
+    "playerId": "lirafe01",
+    "fullName": "Felipe Lira",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Santa Teresa del Tuy",
+    "warCareer": 5.16
+  },
+  {
+    "playerId": "albural01",
+    "fullName": "Al Alburquerque",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 5.13
+  },
+  {
+    "playerId": "taverwi01",
+    "fullName": "Willy Taveras",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Tenares",
+    "warCareer": 5.12
+  },
+  {
+    "playerId": "cabreev01",
+    "fullName": "Everth Cabrera",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Nandaime",
+    "warCareer": 5.1
+  },
+  {
+    "playerId": "kuoho01",
+    "fullName": "Hung-Chih Kuo",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Tainan City",
+    "warCareer": 5.08
+  },
+  {
+    "playerId": "zambrvi01",
+    "fullName": "Victor Zambrano",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Los Teques",
+    "warCareer": 5.08
+  },
+  {
+    "playerId": "guerrju02",
+    "fullName": "Junior Guerra",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felix",
+    "warCareer": 5.07
+  },
+  {
+    "playerId": "francfr01",
+    "fullName": "Frank Francisco",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 5.06
+  },
+  {
+    "playerId": "cruzju02",
+    "fullName": "Juan Cruz",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 5.04
+  },
+  {
+    "playerId": "chaveen01",
+    "fullName": "Endy Chavez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 5.02
+  },
+  {
+    "playerId": "hechaad01",
+    "fullName": "Adeiny Hechavarria",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": 5
+  },
+  {
+    "playerId": "bithohi01",
+    "fullName": "Hi Bithorn",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 4.96
+  },
+  {
+    "playerId": "alvarpe01",
+    "fullName": "Pedro Alvarez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 4.94
+  },
+  {
+    "playerId": "rondohe01",
+    "fullName": "Hector Rondon",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guatire",
+    "warCareer": 4.91
+  },
+  {
+    "playerId": "marreel01",
+    "fullName": "Eli Marrero",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 4.9
+  },
+  {
+    "playerId": "limajo01",
+    "fullName": "Jose Lima",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 4.89
+  },
+  {
+    "playerId": "vizcalu01",
+    "fullName": "Luis Vizcaino",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 4.88
+  },
+  {
+    "playerId": "barojsa01",
+    "fullName": "Salome Barojas",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Cordoba",
+    "warCareer": 4.83
+  },
+  {
+    "playerId": "pinaho01",
+    "fullName": "Horacio Pina",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Matamoros",
+    "warCareer": 4.8
+  },
+  {
+    "playerId": "rincoju01",
+    "fullName": "Juan Rincon",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 4.72
+  },
+  {
+    "playerId": "garceri01",
+    "fullName": "Rich Garces",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 4.71
+  },
+  {
+    "playerId": "carmofa01",
+    "fullName": "Roberto Hernandez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 4.68
+  },
+  {
+    "playerId": "matoslu01",
+    "fullName": "Luis Matos",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 4.68
+  },
+  {
+    "playerId": "quinnjo02",
+    "fullName": "Joe Quinn",
+    "birthYear": 1864,
+    "birthDecade": 1860,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": 4.66
+  },
+  {
+    "playerId": "alvarjo02",
+    "fullName": "Jose Alvarez",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": 4.64
+  },
+  {
+    "playerId": "tavarju01",
+    "fullName": "Julian Tavarez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 4.62
+  },
+  {
+    "playerId": "iwamuak01",
+    "fullName": "Akinori Iwamura",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Uwajima",
+    "warCareer": 4.52
+  },
+  {
+    "playerId": "johnssp01",
+    "fullName": "Spud Johnson",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": 4.52
+  },
+  {
+    "playerId": "alomalu01",
+    "fullName": "Luis Aloma",
+    "birthYear": 1923,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 4.51
+  },
+  {
+    "playerId": "eusebto01",
+    "fullName": "Tony Eusebio",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Los Llanos",
+    "warCareer": 4.46
+  },
+  {
+    "playerId": "avilalu01",
+    "fullName": "Luis Avilan",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 4.45
+  },
+  {
+    "playerId": "tejadru01",
+    "fullName": "Ruben Tejada",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Santiago",
+    "warCareer": 4.45
+  },
+  {
+    "playerId": "lopezwi01",
+    "fullName": "Wilton Lopez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Leon",
+    "warCareer": 4.44
+  },
+  {
+    "playerId": "corpama01",
+    "fullName": "Manny Corpas",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 4.41
+  },
+  {
+    "playerId": "tayloro01",
+    "fullName": "Ron Taylor",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 4.4
+  },
+  {
+    "playerId": "fukudko01",
+    "fullName": "Kosuke Fukudome",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "So-gun",
+    "warCareer": 4.37
+  },
+  {
+    "playerId": "apontlu01",
+    "fullName": "Luis Aponte",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tigre",
+    "warCareer": 4.36
+  },
+  {
+    "playerId": "perezra01",
+    "fullName": "Rafael Perez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 4.34
+  },
+  {
+    "playerId": "blowemi01",
+    "fullName": "Mike Blowers",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Wurzburg",
+    "warCareer": 4.31
+  },
+  {
+    "playerId": "alberha01",
+    "fullName": "Hanser Alberto",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 4.29
+  },
+  {
+    "playerId": "peralwi01",
+    "fullName": "Wily Peralta",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Samana",
+    "warCareer": 4.25
+  },
+  {
+    "playerId": "ramirer02",
+    "fullName": "Erasmo Ramirez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Rivas",
+    "warCareer": 4.25
+  },
+  {
+    "playerId": "greenda03",
+    "fullName": "David Green",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Managua",
+    "warCareer": 4.24
+  },
+  {
+    "playerId": "nunezed01",
+    "fullName": "Ed Nunez",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": 4.23
+  },
+  {
+    "playerId": "mijarjo01",
+    "fullName": "Jose Mijares",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 4.21
+  },
+  {
+    "playerId": "miranan01",
+    "fullName": "Angel Miranda",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": 4.19
+  },
+  {
+    "playerId": "aceveal01",
+    "fullName": "Alfredo Aceves",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Luis Rio Colorado",
+    "warCareer": 4.18
+  },
+  {
+    "playerId": "mercejo02",
+    "fullName": "Jose Mercedes",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": 4.18
+  },
+  {
+    "playerId": "sojolu01",
+    "fullName": "Luis Sojo",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 4.16
+  },
+  {
+    "playerId": "santijo02",
+    "fullName": "Jose Santiago",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Juana Diaz",
+    "warCareer": 4.1
+  },
+  {
+    "playerId": "peraljo01",
+    "fullName": "Joel Peralta",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 4.09
+  },
+  {
+    "playerId": "chacigu01",
+    "fullName": "Gustavo Chacin",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 4.08
+  },
+  {
+    "playerId": "mateoju01",
+    "fullName": "Julio Mateo",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 4.06
+  },
+  {
+    "playerId": "nicolhu01",
+    "fullName": "Hugh Nicol",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Campsie",
+    "warCareer": 4.06
+  },
+  {
+    "playerId": "cabreda01",
+    "fullName": "Daniel Cabrera",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 4.04
+  },
+  {
+    "playerId": "tejedro01",
+    "fullName": "Rob Tejeda",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 4.02
+  },
+  {
+    "playerId": "knowlji01",
+    "fullName": "Jimmy Knowles",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 4
+  },
+  {
+    "playerId": "axforjo01",
+    "fullName": "John Axford",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Simcoe",
+    "warCareer": 3.98
+  },
+  {
+    "playerId": "marqulu01",
+    "fullName": "Luis Marquez",
+    "birthYear": 1925,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aguadilla",
+    "warCareer": 3.94
+  },
+  {
+    "playerId": "espinal01",
+    "fullName": "Alvaro Espinoza",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 3.9
+  },
+  {
+    "playerId": "muldomi01",
+    "fullName": "Mike Muldoon",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 3.9
+  },
+  {
+    "playerId": "polangr01",
+    "fullName": "Gregory Polanco",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.9
+  },
+  {
+    "playerId": "sanchlu01",
+    "fullName": "Luis Sanchez",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cariaco",
+    "warCareer": 3.89
+  },
+  {
+    "playerId": "shinjts01",
+    "fullName": "Tsuyoshi Shinjo",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tsushima",
+    "warCareer": 3.87
+  },
+  {
+    "playerId": "mujiced01",
+    "fullName": "Edward Mujica",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 3.85
+  },
+  {
+    "playerId": "casilal01",
+    "fullName": "Alexi Casilla",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 3.84
+  },
+  {
+    "playerId": "lindjo01",
+    "fullName": "Jose Lind",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Toabaja",
+    "warCareer": 3.84
+  },
+  {
+    "playerId": "garcile02",
+    "fullName": "Leury Garcia",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 3.82
+  },
+  {
+    "playerId": "leonma01",
+    "fullName": "Max Leon",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Acula",
+    "warCareer": 3.82
+  },
+  {
+    "playerId": "verasjo01",
+    "fullName": "Jose Veras",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.8
+  },
+  {
+    "playerId": "sasakka01",
+    "fullName": "Kazuhiro Sasaki",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Sendai",
+    "warCareer": 3.67
+  },
+  {
+    "playerId": "arroylu01",
+    "fullName": "Luis Arroyo",
+    "birthYear": 1927,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Penuelas",
+    "warCareer": 3.65
+  },
+  {
+    "playerId": "vizcaar01",
+    "fullName": "Arodys Vizcaino",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Yaguate",
+    "warCareer": 3.65
+  },
+  {
+    "playerId": "alfonan01",
+    "fullName": "Antonio Alfonseca",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 3.64
+  },
+  {
+    "playerId": "nunezle01",
+    "fullName": "Juan Carlos Oviedo",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 3.64
+  },
+  {
+    "playerId": "mountbi01",
+    "fullName": "Bill Mountjoy",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 3.59
+  },
+  {
+    "playerId": "sarmima01",
+    "fullName": "Manny Sarmiento",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cagua",
+    "warCareer": 3.56
+  },
+  {
+    "playerId": "malonfe01",
+    "fullName": "Fergy Malone",
+    "birthYear": 1844,
+    "birthDecade": 1840,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 3.55
+  },
+  {
+    "playerId": "baezpe01",
+    "fullName": "Pedro Baez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 3.53
+  },
+  {
+    "playerId": "willije01",
+    "fullName": "Jeff Williams",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Canberra",
+    "warCareer": 3.52
+  },
+  {
+    "playerId": "febleca01",
+    "fullName": "Carlos Febles",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": 3.51
+  },
+  {
+    "playerId": "lopezaq01",
+    "fullName": "Aquilino Lopez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Altagracia",
+    "warCareer": 3.48
+  },
+  {
+    "playerId": "irabuhi01",
+    "fullName": "Hideki Irabu",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Hyogo",
+    "warCareer": 3.44
+  },
+  {
+    "playerId": "santado01",
+    "fullName": "Domingo Santana",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.44
+  },
+  {
+    "playerId": "refsnro01",
+    "fullName": "Rob Refsnyder",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Seoul",
+    "warCareer": 3.4
+  },
+  {
+    "playerId": "nieveju01",
+    "fullName": "Juan Nieves",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 3.39
+  },
+  {
+    "playerId": "hernaru03",
+    "fullName": "Runelvys Hernandez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.33
+  },
+  {
+    "playerId": "robinhu01",
+    "fullName": "Humberto Robinson",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 3.31
+  },
+  {
+    "playerId": "pintore01",
+    "fullName": "Renyel Pinto",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cupira",
+    "warCareer": 3.3
+  },
+  {
+    "playerId": "torrepa01",
+    "fullName": "Pablo Torrealba",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 3.29
+  },
+  {
+    "playerId": "diazei01",
+    "fullName": "Einar Diaz",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": null,
+    "warCareer": 3.28
+  },
+  {
+    "playerId": "dibutpe01",
+    "fullName": "Pedro Dibut",
+    "birthYear": 1892,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cienfuegos",
+    "warCareer": 3.28
+  },
+  {
+    "playerId": "deleolu01",
+    "fullName": "Luis DeLeon",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 3.26
+  },
+  {
+    "playerId": "prietar01",
+    "fullName": "Ariel Prieto",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 3.24
+  },
+  {
+    "playerId": "ohmanwi01",
+    "fullName": "Will Ohman",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Frankfurt",
+    "warCareer": 3.23
+  },
+  {
+    "playerId": "garcilu03",
+    "fullName": "Luis Garcia",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.2
+  },
+  {
+    "playerId": "abadfe01",
+    "fullName": "Fernando Abad",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 3.18
+  },
+  {
+    "playerId": "bonifem01",
+    "fullName": "Emilio Bonifacio",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.18
+  },
+  {
+    "playerId": "sosajo02",
+    "fullName": "Jorge Sosa",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 3.18
+  },
+  {
+    "playerId": "duceyro01",
+    "fullName": "Rob Ducey",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 3.17
+  },
+  {
+    "playerId": "herremi01",
+    "fullName": "Mike Herrera",
+    "birthYear": 1897,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 3.16
+  },
+  {
+    "playerId": "amezaal01",
+    "fullName": "Alfredo Amezaga",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Obregon",
+    "warCareer": 3.15
+  },
+  {
+    "playerId": "raymocl01",
+    "fullName": "Claude Raymond",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. Jean",
+    "warCareer": 3.13
+  },
+  {
+    "playerId": "castrmi01",
+    "fullName": "Miguel Castro",
+    "birthYear": 1994,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 3.11
+  },
+  {
+    "playerId": "espinni01",
+    "fullName": "Nino Espinosa",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Altagracia",
+    "warCareer": 3.06
+  },
+  {
+    "playerId": "fieldjo01",
+    "fullName": "Jocko Fields",
+    "birthYear": 1864,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Cork",
+    "warCareer": 3.06
+  },
+  {
+    "playerId": "molinjo01",
+    "fullName": "Jose Molina",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 3.06
+  },
+  {
+    "playerId": "castrra01",
+    "fullName": "Ramon Castro",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vega Baja",
+    "warCareer": 3.04
+  },
+  {
+    "playerId": "dicksja01",
+    "fullName": "Jason Dickson",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 3.04
+  },
+  {
+    "playerId": "strakle01",
+    "fullName": "Les Straker",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": 3.03
+  },
+  {
+    "playerId": "lopezma01",
+    "fullName": "Marcelino Lopez",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 3.02
+  },
+  {
+    "playerId": "aguilje01",
+    "fullName": "Jesus Aguilar",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 2.99
+  },
+  {
+    "playerId": "ericker01",
+    "fullName": "Eric Erickson",
+    "birthYear": 1892,
+    "birthDecade": 1890,
+    "birthCountry": "Sweden",
+    "birthCountryRaw": "Sweden",
+    "birthCity": "Vargarda",
+    "warCareer": 2.99
+  },
+  {
+    "playerId": "liriane01",
+    "fullName": "Nelson Liriano",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": 2.99
+  },
+  {
+    "playerId": "griffal01",
+    "fullName": "Alfredo Griffin",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 2.97
+  },
+  {
+    "playerId": "woltery01",
+    "fullName": "Rynie Wolters",
+    "birthYear": 1842,
+    "birthDecade": 1840,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Schantz",
+    "warCareer": 2.96
+  },
+  {
+    "playerId": "addybo01",
+    "fullName": "Bob Addy",
+    "birthYear": 1842,
+    "birthDecade": 1840,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Port Hope",
+    "warCareer": 2.93
+  },
+  {
+    "playerId": "vickeru01",
+    "fullName": "Rube Vickers",
+    "birthYear": 1878,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. Mary's",
+    "warCareer": 2.91
+  },
+  {
+    "playerId": "marsaar01",
+    "fullName": "Armando Marsans",
+    "birthYear": 1887,
+    "birthDecade": 1880,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Matanzas",
+    "warCareer": 2.9
+  },
+  {
+    "playerId": "kottage01",
+    "fullName": "George Kottaras",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Scarborough",
+    "warCareer": 2.85
+  },
+  {
+    "playerId": "cogswed01",
+    "fullName": "Ed Cogswell",
+    "birthYear": 1854,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": 2.82
+  },
+  {
+    "playerId": "medinyo01",
+    "fullName": "Yoervis Medina",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": 2.82
+  },
+  {
+    "playerId": "garciyi01",
+    "fullName": "Yimi Garcia",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Moca",
+    "warCareer": 2.81
+  },
+  {
+    "playerId": "hanfoch01",
+    "fullName": "Charlie Hanford",
+    "birthYear": 1882,
+    "birthDecade": 1880,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Tunstall",
+    "warCareer": 2.8
+  },
+  {
+    "playerId": "waddeto01",
+    "fullName": "Tom Waddell",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Dundee",
+    "warCareer": 2.8
+  },
+  {
+    "playerId": "perezhe01",
+    "fullName": "Hernan Perez",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Villa de Cura",
+    "warCareer": 2.79
+  },
+  {
+    "playerId": "gilbe01",
+    "fullName": "Benji Gil",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": 2.78
+  },
+  {
+    "playerId": "betemwi01",
+    "fullName": "Wilson Betemit",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 2.77
+  },
+  {
+    "playerId": "ledeeri01",
+    "fullName": "Ricky Ledee",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 2.75
+  },
+  {
+    "playerId": "vargacl01",
+    "fullName": "Claudio Vargas",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Mao",
+    "warCareer": 2.75
+  },
+  {
+    "playerId": "aybarwi01",
+    "fullName": "Willy Aybar",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 2.74
+  },
+  {
+    "playerId": "bastaan01",
+    "fullName": "Antonio Bastardo",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": 2.73
+  },
+  {
+    "playerId": "milledo03",
+    "fullName": "Doc Miller",
+    "birthYear": 1883,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Chatham",
+    "warCareer": 2.73
+  },
+  {
+    "playerId": "riosar01",
+    "fullName": "Armando Rios",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 2.73
+  },
+  {
+    "playerId": "dedunsa01",
+    "fullName": "Sam Deduno",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 2.72
+  },
+  {
+    "playerId": "kelluwi01",
+    "fullName": "Win Kellum",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Waterford",
+    "warCareer": 2.72
+  },
+  {
+    "playerId": "aguaylu01",
+    "fullName": "Luis Aguayo",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vega Baja",
+    "warCareer": 2.71
+  },
+  {
+    "playerId": "aceveju01",
+    "fullName": "Juan Acevedo",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Juarez",
+    "warCareer": 2.7
+  },
+  {
+    "playerId": "donosli01",
+    "fullName": "Lino Donoso",
+    "birthYear": 1922,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 2.7
+  },
+  {
+    "playerId": "quintca01",
+    "fullName": "Carlos Quintana",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Mamporal",
+    "warCareer": 2.69
+  },
+  {
+    "playerId": "nicasju01",
+    "fullName": "Juan Nicasio",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 2.62
+  },
+  {
+    "playerId": "choihe01",
+    "fullName": "Hee-Seop Choi",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Chun-Nam",
+    "warCareer": 2.61
+  },
+  {
+    "playerId": "manrifr01",
+    "fullName": "Fred Manrique",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": 2.59
+  },
+  {
+    "playerId": "arredjo01",
+    "fullName": "Jose Arredondo",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 2.58
+  },
+  {
+    "playerId": "paniajo01",
+    "fullName": "Jose Paniagua",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Jose de Ocoa",
+    "warCareer": 2.58
+  },
+  {
+    "playerId": "perezne01",
+    "fullName": "Neifi Perez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": 2.58
+  },
+  {
+    "playerId": "barfijo02",
+    "fullName": "Josh Barfield",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 2.57
+  },
+  {
+    "playerId": "herrepa01",
+    "fullName": "Pancho Herrera",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de las Vegas",
+    "warCareer": 2.56
+  },
+  {
+    "playerId": "machaju01",
+    "fullName": "Julio Machado",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Carlos del Zulia",
+    "warCareer": 2.56
+  },
+  {
+    "playerId": "webstra02",
+    "fullName": "Ramon Webster",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 2.56
+  },
+  {
+    "playerId": "villaos01",
+    "fullName": "Oscar Villarreal",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Nicolas de los Garza",
+    "warCareer": 2.54
+  },
+  {
+    "playerId": "needhto01",
+    "fullName": "Tom Needham",
+    "birthYear": 1879,
+    "birthDecade": 1870,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 2.53
+  },
+  {
+    "playerId": "fossato01",
+    "fullName": "Tony Fossas",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 2.5
+  },
+  {
+    "playerId": "dilonmi01",
+    "fullName": "Miguel Dilone",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 2.48
+  },
+  {
+    "playerId": "riverbo01",
+    "fullName": "Bombo Rivera",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 2.48
+  },
+  {
+    "playerId": "clarkwe01",
+    "fullName": "Webbo Clarke",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 2.46
+  },
+  {
+    "playerId": "galarar01",
+    "fullName": "Armando Galarraga",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": 2.46
+  },
+  {
+    "playerId": "robleha01",
+    "fullName": "Hansel Robles",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 2.39
+  },
+  {
+    "playerId": "rodrihe02",
+    "fullName": "Henry Rodriguez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 2.39
+  },
+  {
+    "playerId": "sanchjo01",
+    "fullName": "Jonathan Sanchez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": 2.37
+  },
+  {
+    "playerId": "delgara01",
+    "fullName": "Randall Delgado",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Las Tablas",
+    "warCareer": 2.34
+  },
+  {
+    "playerId": "melenjo01",
+    "fullName": "Jose Melendez",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Naguabo",
+    "warCareer": 2.34
+  },
+  {
+    "playerId": "bonilju01",
+    "fullName": "Juan Bonilla",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 2.33
+  },
+  {
+    "playerId": "bowsfte01",
+    "fullName": "Ted Bowsfield",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vernon",
+    "warCareer": 2.31
+  },
+  {
+    "playerId": "jimenjo01",
+    "fullName": "Jose Jimenez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 2.31
+  },
+  {
+    "playerId": "bochybr01",
+    "fullName": "Bruce Bochy",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": "Landes de Bussac",
+    "warCareer": 2.29
+  },
+  {
+    "playerId": "amaroru01",
+    "fullName": "Ruben Amaro",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Nuevo Laredo",
+    "warCareer": 2.27
+  },
+  {
+    "playerId": "bahred01",
+    "fullName": "Ed Bahr",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Rouleau",
+    "warCareer": 2.23
+  },
+  {
+    "playerId": "hernaca03",
+    "fullName": "Carlos Hernandez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guacara",
+    "warCareer": 2.21
+  },
+  {
+    "playerId": "salasfe01",
+    "fullName": "Fernando Salas",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Huatabampo",
+    "warCareer": 2.21
+  },
+  {
+    "playerId": "wilsost01",
+    "fullName": "Steve Wilson",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Victoria",
+    "warCareer": 2.21
+  },
+  {
+    "playerId": "riverre01",
+    "fullName": "Rene Rivera",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 2.18
+  },
+  {
+    "playerId": "severpe01",
+    "fullName": "Pedro Severino",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 2.18
+  },
+  {
+    "playerId": "tagucso01",
+    "fullName": "So Taguchi",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Fukuoka",
+    "warCareer": 2.17
+  },
+  {
+    "playerId": "martich01",
+    "fullName": "Chito Martinez",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Belize",
+    "birthCountryRaw": "Belize",
+    "birthCity": "Belize",
+    "warCareer": 2.16
+  },
+  {
+    "playerId": "tazawju01",
+    "fullName": "Junichi Tazawa",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Yokohama",
+    "warCareer": 2.16
+  },
+  {
+    "playerId": "takatsh01",
+    "fullName": "Shingo Takatsu",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Hiroshima",
+    "warCareer": 2.14
+  },
+  {
+    "playerId": "olivodi01",
+    "fullName": "Diomedes Olivo",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guayubin",
+    "warCareer": 2.13
+  },
+  {
+    "playerId": "cocanja01",
+    "fullName": "Jaime Cocanower",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 2.11
+  },
+  {
+    "playerId": "perezmi01",
+    "fullName": "Mike Perez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Yauco",
+    "warCareer": 2.11
+  },
+  {
+    "playerId": "manguan01",
+    "fullName": "Angel Mangual",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Juana Diaz",
+    "warCareer": 2.1
+  },
+  {
+    "playerId": "riversa01",
+    "fullName": "Saul Rivera",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 2.1
+  },
+  {
+    "playerId": "urenajo01",
+    "fullName": "Jose Urena",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 2.1
+  },
+  {
+    "playerId": "eliasro01",
+    "fullName": "Roenis Elias",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guantanamo",
+    "warCareer": 2.08
+  },
+  {
+    "playerId": "gonzaje01",
+    "fullName": "Geremi Gonzalez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 2.08
+  },
+  {
+    "playerId": "diamosc01",
+    "fullName": "Scott Diamond",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Guelph",
+    "warCareer": 2.07
+  },
+  {
+    "playerId": "machije01",
+    "fullName": "Jean Machi",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tigre",
+    "warCareer": 2.07
+  },
+  {
+    "playerId": "steelbo01",
+    "fullName": "Bob Steele",
+    "birthYear": 1894,
+    "birthDecade": 1890,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Cassburn",
+    "warCareer": 2.06
+  },
+  {
+    "playerId": "asencmi01",
+    "fullName": "Miguel Asencio",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": 2.05
+  },
+  {
+    "playerId": "reyesna01",
+    "fullName": "Nap Reyes",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": 2.05
+  },
+  {
+    "playerId": "santada01",
+    "fullName": "Danny Santana",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Plata",
+    "warCareer": 2.05
+  },
+  {
+    "playerId": "linarru01",
+    "fullName": "Rufino Linares",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 2.04
+  },
+  {
+    "playerId": "torrefe01",
+    "fullName": "Felix Torres",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 2.03
+  },
+  {
+    "playerId": "torreal01",
+    "fullName": "Alex Torres",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 2
+  },
+  {
+    "playerId": "frierer01",
+    "fullName": "Ernesto Frieri",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Bolivar",
+    "warCareer": 1.99
+  },
+  {
+    "playerId": "floripe01",
+    "fullName": "Pedro Florimon",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 1.97
+  },
+  {
+    "playerId": "acostjo01",
+    "fullName": "Jose Acosta",
+    "birthYear": 1891,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 1.93
+  },
+  {
+    "playerId": "moralfr01",
+    "fullName": "Franklin Morales",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Juan de los Morros",
+    "warCareer": 1.93
+  },
+  {
+    "playerId": "maciajo01",
+    "fullName": "Jose Macias",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 1.92
+  },
+  {
+    "playerId": "moscogu01",
+    "fullName": "Guillermo Moscoso",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 1.9
+  },
+  {
+    "playerId": "penato03",
+    "fullName": "Tony Pena",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 1.89
+  },
+  {
+    "playerId": "tabatjo01",
+    "fullName": "Jose Tabata",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tigre",
+    "warCareer": 1.89
+  },
+  {
+    "playerId": "irwinjo01",
+    "fullName": "John Irwin",
+    "birthYear": 1861,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 1.88
+  },
+  {
+    "playerId": "krakajo01",
+    "fullName": "Joe Krakauskas",
+    "birthYear": 1915,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": 1.86
+  },
+  {
+    "playerId": "guielaa01",
+    "fullName": "Aaron Guiel",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": 1.85
+  },
+  {
+    "playerId": "paintla01",
+    "fullName": "Lance Painter",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Bedford",
+    "warCareer": 1.85
+  },
+  {
+    "playerId": "cedenxa01",
+    "fullName": "Xavier Cedeno",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guayanilla",
+    "warCareer": 1.84
+  },
+  {
+    "playerId": "altheaa01",
+    "fullName": "Aaron Altherr",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Landstuhl",
+    "warCareer": 1.83
+  },
+  {
+    "playerId": "fermife01",
+    "fullName": "Felix Fermin",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Mao",
+    "warCareer": 1.83
+  },
+  {
+    "playerId": "perezed02",
+    "fullName": "Eddie Perez",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Ojeda",
+    "warCareer": 1.83
+  },
+  {
+    "playerId": "taverfr01",
+    "fullName": "Frank Taveras",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Santa Cruz",
+    "warCareer": 1.82
+  },
+  {
+    "playerId": "quinthu01",
+    "fullName": "Humberto Quintero",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 1.8
+  },
+  {
+    "playerId": "guzmaje01",
+    "fullName": "Jesus Guzman",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": 1.79
+  },
+  {
+    "playerId": "henriol01",
+    "fullName": "Olaf Henriksen",
+    "birthYear": 1888,
+    "birthDecade": 1880,
+    "birthCountry": "Denmark",
+    "birthCountryRaw": "Denmark",
+    "birthCity": "Kirkerup",
+    "warCareer": 1.79
+  },
+  {
+    "playerId": "wadats01",
+    "fullName": "Tsuyoshi Wada",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Konan",
+    "warCareer": 1.79
+  },
+  {
+    "playerId": "valerju01",
+    "fullName": "Julio Valera",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aguadilla",
+    "warCareer": 1.78
+  },
+  {
+    "playerId": "olmolu01",
+    "fullName": "Luis Olmo",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": 1.73
+  },
+  {
+    "playerId": "welzeto01",
+    "fullName": "Tony Welzer",
+    "birthYear": 1899,
+    "birthDecade": 1890,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": 1.73
+  },
+  {
+    "playerId": "blancan01",
+    "fullName": "Andres Blanco",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Urama",
+    "warCareer": 1.72
+  },
+  {
+    "playerId": "carragi01",
+    "fullName": "Giovanni Carrara",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tigre",
+    "warCareer": 1.72
+  },
+  {
+    "playerId": "harknti01",
+    "fullName": "Tim Harkness",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Lachine",
+    "warCareer": 1.71
+  },
+  {
+    "playerId": "hillsh01",
+    "fullName": "Shawn Hill",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Mississauga",
+    "warCareer": 1.7
+  },
+  {
+    "playerId": "riverbe01",
+    "fullName": "Ben Rivera",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 1.7
+  },
+  {
+    "playerId": "cedenro01",
+    "fullName": "Roger Cedeno",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 1.69
+  },
+  {
+    "playerId": "mossda01",
+    "fullName": "Damian Moss",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Darlinghurst",
+    "warCareer": 1.69
+  },
+  {
+    "playerId": "orlanpa01",
+    "fullName": "Paulo Orlando",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Brazil",
+    "birthCountryRaw": "Brazil",
+    "birthCity": "Sao Paulo",
+    "warCareer": 1.68
+  },
+  {
+    "playerId": "castial01",
+    "fullName": "Alberto Castillo",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Juan de la Maguana",
+    "warCareer": 1.66
+  },
+  {
+    "playerId": "linesdi01",
+    "fullName": "Dick Lines",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": 1.66
+  },
+  {
+    "playerId": "olivefr01",
+    "fullName": "Francisco Oliveras",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 1.66
+  },
+  {
+    "playerId": "sanchdu01",
+    "fullName": "Duaner Sanchez",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": 1.65
+  },
+  {
+    "playerId": "lopezca01",
+    "fullName": "Carlos Lopez",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mazatlan",
+    "warCareer": 1.62
+  },
+  {
+    "playerId": "montawi01",
+    "fullName": "Willie Montanez",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Catano",
+    "warCareer": 1.62
+  },
+  {
+    "playerId": "milleor01",
+    "fullName": "Orlando Miller",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Changuinola",
+    "warCareer": 1.6
+  },
+  {
+    "playerId": "germaes01",
+    "fullName": "Esteban German",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 1.59
+  },
+  {
+    "playerId": "almanca01",
+    "fullName": "Carlos Almanzar",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 1.58
+  },
+  {
+    "playerId": "vargake01",
+    "fullName": "Kennys Vargas",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Canovanas",
+    "warCareer": 1.58
+  },
+  {
+    "playerId": "rosarwi01",
+    "fullName": "Wilin Rosario",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 1.57
+  },
+  {
+    "playerId": "martisi01",
+    "fullName": "Silvio Martinez",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 1.55
+  },
+  {
+    "playerId": "villahe01",
+    "fullName": "Hector Villanueva",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 1.55
+  },
+  {
+    "playerId": "baezjo01",
+    "fullName": "Jose Baez",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 1.54
+  },
+  {
+    "playerId": "cruzne01",
+    "fullName": "Nelson Cruz",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": 1.54
+  },
+  {
+    "playerId": "juliojo01",
+    "fullName": "Jorge Julio",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 1.54
+  },
+  {
+    "playerId": "knighjo01",
+    "fullName": "Joe Knight",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Port Stanley",
+    "warCareer": 1.54
+  },
+  {
+    "playerId": "pavlada01",
+    "fullName": "Dave Pavlas",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Frankfurt",
+    "warCareer": 1.54
+  },
+  {
+    "playerId": "kawasmu01",
+    "fullName": "Munenori Kawasaki",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Aira-gun",
+    "warCareer": 1.53
+  },
+  {
+    "playerId": "foleycu01",
+    "fullName": "Curry Foley",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Milltown",
+    "warCareer": 1.52
+  },
+  {
+    "playerId": "gonzawi01",
+    "fullName": "Wiki Gonzalez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": 1.51
+  },
+  {
+    "playerId": "santone01",
+    "fullName": "Nelson Santovenia",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": 1.49
+  },
+  {
+    "playerId": "wilkile01",
+    "fullName": "Lefty Wilkie",
+    "birthYear": 1914,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Zealandia",
+    "warCareer": 1.49
+  },
+  {
+    "playerId": "perezti01",
+    "fullName": "Timo Perez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 1.48
+  },
+  {
+    "playerId": "murakma01",
+    "fullName": "Masanori Murakami",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kita Tsuru-gun",
+    "warCareer": 1.47
+  },
+  {
+    "playerId": "escobal01",
+    "fullName": "Alex Escobar",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 1.46
+  },
+  {
+    "playerId": "cruzlu01",
+    "fullName": "Luis Cruz",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Navojoa",
+    "warCareer": 1.44
+  },
+  {
+    "playerId": "noblera01",
+    "fullName": "Ray Noble",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Central Hatillo",
+    "warCareer": 1.44
+  },
+  {
+    "playerId": "halliji01",
+    "fullName": "Jimmy Hallinan",
+    "birthYear": 1849,
+    "birthDecade": 1840,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 1.43
+  },
+  {
+    "playerId": "zamoros01",
+    "fullName": "Oscar Zamora",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Camaguey",
+    "warCareer": 1.43
+  },
+  {
+    "playerId": "vazqura01",
+    "fullName": "Ramon Vazquez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aibonito",
+    "warCareer": 1.42
+  },
+  {
+    "playerId": "campijo01",
+    "fullName": "Jorge Campillo",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": 1.41
+  },
+  {
+    "playerId": "dominju01",
+    "fullName": "Juan Dominguez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sanchez Ramirez",
+    "warCareer": 1.41
+  },
+  {
+    "playerId": "rossyri01",
+    "fullName": "Rico Rossy",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 1.41
+  },
+  {
+    "playerId": "chouibo01",
+    "fullName": "Bobby Chouinard",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Philippines",
+    "birthCountryRaw": "Philippines",
+    "birthCity": "Manila",
+    "warCareer": 1.4
+  },
+  {
+    "playerId": "mangupe01",
+    "fullName": "Pepe Mangual",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 1.39
+  },
+  {
+    "playerId": "rojasmi01",
+    "fullName": "Minnie Rojas",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Remedios",
+    "warCareer": 1.39
+  },
+  {
+    "playerId": "bernaro01",
+    "fullName": "Roger Bernadina",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 1.38
+  },
+  {
+    "playerId": "francju02",
+    "fullName": "Juan Francisco",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 1.38
+  },
+  {
+    "playerId": "gonzape01",
+    "fullName": "Pedro Gonzalez",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 1.35
+  },
+  {
+    "playerId": "chacoel01",
+    "fullName": "Elio Chacon",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 1.34
+  },
+  {
+    "playerId": "colonch01",
+    "fullName": "Christian Colon",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Cayey",
+    "warCareer": 1.32
+  },
+  {
+    "playerId": "delarru01",
+    "fullName": "Rubby De La Rosa",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 1.32
+  },
+  {
+    "playerId": "rodrihe01",
+    "fullName": "Hector Rodriguez",
+    "birthYear": 1920,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Alquizar",
+    "warCareer": 1.32
+  },
+  {
+    "playerId": "correed01",
+    "fullName": "Ed Correa",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Hato Rey",
+    "warCareer": 1.31
+  },
+  {
+    "playerId": "arochre01",
+    "fullName": "Rene Arocha",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 1.28
+  },
+  {
+    "playerId": "agostju01",
+    "fullName": "Juan Agosto",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 1.26
+  },
+  {
+    "playerId": "baekch01",
+    "fullName": "Cha-Seung Baek",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Pusan",
+    "warCareer": 1.25
+  },
+  {
+    "playerId": "cisnejo01",
+    "fullName": "Jose Cisnero",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 1.25
+  },
+  {
+    "playerId": "lugoru01",
+    "fullName": "Ruddy Lugo",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": 1.25
+  },
+  {
+    "playerId": "navarju01",
+    "fullName": "Julio Navarro",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vieques",
+    "warCareer": 1.25
+  },
+  {
+    "playerId": "hinojda01",
+    "fullName": "Dalier Hinojosa",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Isla de la Juventud",
+    "warCareer": 1.24
+  },
+  {
+    "playerId": "hendeji01",
+    "fullName": "Jim Henderson",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Calgary",
+    "warCareer": 1.23
+  },
+  {
+    "playerId": "riverlu01",
+    "fullName": "Luis Rivera",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Cidra",
+    "warCareer": 1.22
+  },
+  {
+    "playerId": "torrero01",
+    "fullName": "Ronald Torreyes",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Libertador",
+    "warCareer": 1.22
+  },
+  {
+    "playerId": "guzmaan01",
+    "fullName": "Angel Guzman",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 1.21
+  },
+  {
+    "playerId": "owensfr01",
+    "fullName": "Yip Owens",
+    "birthYear": 1886,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 1.21
+  },
+  {
+    "playerId": "casanpa01",
+    "fullName": "Paul Casanova",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Colon",
+    "warCareer": 1.2
+  },
+  {
+    "playerId": "santijo03",
+    "fullName": "Jose Santiago",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": 1.2
+  },
+  {
+    "playerId": "bakerje03",
+    "fullName": "Jeff Baker",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Bad Kissingen",
+    "warCareer": 1.19
+  },
+  {
+    "playerId": "ordonre01",
+    "fullName": "Rey Ordonez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 1.18
+  },
+  {
+    "playerId": "perezca02",
+    "fullName": "Carlos Perez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 1.18
+  },
+  {
+    "playerId": "buenofr01",
+    "fullName": "Francisley Bueno",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 1.17
+  },
+  {
+    "playerId": "marinjh01",
+    "fullName": "Jhan Marinez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 1.17
+  },
+  {
+    "playerId": "vicieda01",
+    "fullName": "Dayan Viciedo",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Remedios",
+    "warCareer": 1.14
+  },
+  {
+    "playerId": "sanchal03",
+    "fullName": "Alex Sanchez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 1.12
+  },
+  {
+    "playerId": "mendero01",
+    "fullName": "Roman Mendez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 1.09
+  },
+  {
+    "playerId": "bethach01",
+    "fullName": "Christian Bethancourt",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 1.07
+  },
+  {
+    "playerId": "gilge01",
+    "fullName": "Geronimo Gil",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Estacion Lagunas",
+    "warCareer": 1.05
+  },
+  {
+    "playerId": "ariasjo01",
+    "fullName": "Joaquin Arias",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 1.04
+  },
+  {
+    "playerId": "horsmvi01",
+    "fullName": "Vince Horsman",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Halifax",
+    "warCareer": 1.04
+  },
+  {
+    "playerId": "robersh01",
+    "fullName": "Sherry Robertson",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": 1.04
+  },
+  {
+    "playerId": "jimence01",
+    "fullName": "Cesar Jimenez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": 1.03
+  },
+  {
+    "playerId": "martipe03",
+    "fullName": "Pedro Martinez",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": 1.03
+  },
+  {
+    "playerId": "ramirra03",
+    "fullName": "Ramon Ramirez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cagua",
+    "warCareer": 1.03
+  },
+  {
+    "playerId": "beckehe02",
+    "fullName": "Heinz Becker",
+    "birthYear": 1915,
+    "birthDecade": 1910,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Berlin",
+    "warCareer": 1.02
+  },
+  {
+    "playerId": "almadme01",
+    "fullName": "Mel Almada",
+    "birthYear": 1913,
+    "birthDecade": 1910,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Huatabampo",
+    "warCareer": 1.01
+  },
+  {
+    "playerId": "almeira01",
+    "fullName": "Rafael Almeida",
+    "birthYear": 1887,
+    "birthDecade": 1880,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 1.01
+  },
+  {
+    "playerId": "ayalabe01",
+    "fullName": "Benny Ayala",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Yauco",
+    "warCareer": 1.01
+  },
+  {
+    "playerId": "mejiaro01",
+    "fullName": "Roman Mejias",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Abreus",
+    "warCareer": 1.01
+  },
+  {
+    "playerId": "nievefe01",
+    "fullName": "Fernando Nieve",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": 1.01
+  },
+  {
+    "playerId": "garcica01",
+    "fullName": "Carlos Garcia",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Tachira",
+    "warCareer": 1
+  },
+  {
+    "playerId": "kawakke01",
+    "fullName": "Kenshin Kawakami",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokushima",
+    "warCareer": 1
+  },
+  {
+    "playerId": "koehlbe01",
+    "fullName": "Ben Koehler",
+    "birthYear": 1877,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Schoerndorn",
+    "warCareer": 1
+  },
+  {
+    "playerId": "adriaeh01",
+    "fullName": "Ehire Adrianza",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guarenas",
+    "warCareer": 0.99
+  },
+  {
+    "playerId": "berroan01",
+    "fullName": "Angel Berroa",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.99
+  },
+  {
+    "playerId": "escarch01",
+    "fullName": "Chico Escarrega",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": 0.99
+  },
+  {
+    "playerId": "penara02",
+    "fullName": "Ramiro Pena",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monterrey",
+    "warCareer": 0.99
+  },
+  {
+    "playerId": "yanes01",
+    "fullName": "Esteban Yan",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Campina",
+    "warCareer": 0.99
+  },
+  {
+    "playerId": "almonab01",
+    "fullName": "Abraham Almonte",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.98
+  },
+  {
+    "playerId": "infangr01",
+    "fullName": "Greg Infante",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.97
+  },
+  {
+    "playerId": "padilju01",
+    "fullName": "Juan Padilla",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.97
+  },
+  {
+    "playerId": "salmoch01",
+    "fullName": "Chico Salmon",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 0.97
+  },
+  {
+    "playerId": "simonal01",
+    "fullName": "Alfredo Simon",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 0.97
+  },
+  {
+    "playerId": "monzara01",
+    "fullName": "Ramon Monzant",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.95
+  },
+  {
+    "playerId": "huttoma01",
+    "fullName": "Mark Hutton",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "South Adelaide",
+    "warCareer": 0.93
+  },
+  {
+    "playerId": "ortizhe01",
+    "fullName": "Hector Ortiz",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.93
+  },
+  {
+    "playerId": "cummimi01",
+    "fullName": "Midre Cummings",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Christiansted",
+    "warCareer": 0.92
+  },
+  {
+    "playerId": "wrighha01",
+    "fullName": "Harry Wright",
+    "birthYear": 1835,
+    "birthDecade": 1830,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Sheffield",
+    "warCareer": 0.92
+  },
+  {
+    "playerId": "floreje02",
+    "fullName": "Jesus Flores",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Carupano",
+    "warCareer": 0.91
+  },
+  {
+    "playerId": "germafr01",
+    "fullName": "Franklyn German",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.91
+  },
+  {
+    "playerId": "acostma01",
+    "fullName": "Manny Acosta",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": 0.9
+  },
+  {
+    "playerId": "atkinbi01",
+    "fullName": "Bill Atkinson",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Chatham",
+    "warCareer": 0.9
+  },
+  {
+    "playerId": "delosva01",
+    "fullName": "Valerio De Los Santos",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": 0.9
+  },
+  {
+    "playerId": "martife01",
+    "fullName": "Felix Martinez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": 0.89
+  },
+  {
+    "playerId": "murphla01",
+    "fullName": "Larry Murphy",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 0.88
+  },
+  {
+    "playerId": "thompri03",
+    "fullName": "Rich Thompson",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Hornsby",
+    "warCareer": 0.86
+  },
+  {
+    "playerId": "castrfa01",
+    "fullName": "Fabio Castro",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": 0.83
+  },
+  {
+    "playerId": "corteda01",
+    "fullName": "David Cortes",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexicali",
+    "warCareer": 0.83
+  },
+  {
+    "playerId": "nunezab01",
+    "fullName": "Abraham Nunez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.82
+  },
+  {
+    "playerId": "ortegra01",
+    "fullName": "Rafael Ortega",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tigre",
+    "warCareer": 0.82
+  },
+  {
+    "playerId": "pedrial01",
+    "fullName": "Al Pedrique",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 0.82
+  },
+  {
+    "playerId": "penaju01",
+    "fullName": "Juan Pena",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.82
+  },
+  {
+    "playerId": "roberwi01",
+    "fullName": "Willis Roberts",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.82
+  },
+  {
+    "playerId": "thomava01",
+    "fullName": "Valmy Thomas",
+    "birthYear": 1925,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 0.82
+  },
+  {
+    "playerId": "valenja01",
+    "fullName": "Javier Valentin",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Manati",
+    "warCareer": 0.81
+  },
+  {
+    "playerId": "alouje01",
+    "fullName": "Jesus Alou",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 0.8
+  },
+  {
+    "playerId": "pintojo01",
+    "fullName": "Josmil Pinto",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 0.8
+  },
+  {
+    "playerId": "belisro01",
+    "fullName": "Ronald Belisario",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 0.79
+  },
+  {
+    "playerId": "herrejo03",
+    "fullName": "Jonathan Herrera",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.79
+  },
+  {
+    "playerId": "albaljo01",
+    "fullName": "Jonathan Albaladejo",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": 0.78
+  },
+  {
+    "playerId": "gardero01",
+    "fullName": "Ron Gardenhire",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Butzbach",
+    "warCareer": 0.78
+  },
+  {
+    "playerId": "gotayju01",
+    "fullName": "Julio Gotay",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": 0.78
+  },
+  {
+    "playerId": "pascuca01",
+    "fullName": "Carlos Pascual",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.78
+  },
+  {
+    "playerId": "takahhi01",
+    "fullName": "Hisanori Takahashi",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": 0.78
+  },
+  {
+    "playerId": "kimsu01",
+    "fullName": "Sun-Woo Kim",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Inchon",
+    "warCareer": 0.77
+  },
+  {
+    "playerId": "riverge01",
+    "fullName": "German Rivera",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 0.77
+  },
+  {
+    "playerId": "carreez01",
+    "fullName": "Ezequiel Carrera",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guiria",
+    "warCareer": 0.76
+  },
+  {
+    "playerId": "ciriape01",
+    "fullName": "Pedro Ciriaco",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.76
+  },
+  {
+    "playerId": "constjo01",
+    "fullName": "Jose Constanza",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.76
+  },
+  {
+    "playerId": "troncra01",
+    "fullName": "Ramon Troncoso",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Jose de Ocoa",
+    "warCareer": 0.76
+  },
+  {
+    "playerId": "yabuke01",
+    "fullName": "Keiichi Yabu",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Minami Muro-gun",
+    "warCareer": 0.76
+  },
+  {
+    "playerId": "murreiv01",
+    "fullName": "Ivan Murrell",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": null,
+    "warCareer": 0.74
+  },
+  {
+    "playerId": "norbejo01",
+    "fullName": "Jordan Norberto",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": 0.74
+  },
+  {
+    "playerId": "rodriri03",
+    "fullName": "Ricardo Rodriguez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guayubin",
+    "warCareer": 0.74
+  },
+  {
+    "playerId": "rowlary01",
+    "fullName": "Ryan Rowland-Smith",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": 0.74
+  },
+  {
+    "playerId": "manzajo01",
+    "fullName": "Josias Manzanillo",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.73
+  },
+  {
+    "playerId": "burgoam01",
+    "fullName": "Ambiorix Burgos",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": 0.72
+  },
+  {
+    "playerId": "borbope02",
+    "fullName": "Pedro Borbon",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Mao",
+    "warCareer": 0.71
+  },
+  {
+    "playerId": "dolsifr01",
+    "fullName": "Freddy Dolsi",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.71
+  },
+  {
+    "playerId": "peguefr01",
+    "fullName": "Francisco Peguero",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nigua",
+    "warCareer": 0.71
+  },
+  {
+    "playerId": "valdeef01",
+    "fullName": "Efrain Valdez",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nizao",
+    "warCareer": 0.71
+  },
+  {
+    "playerId": "marakpa01",
+    "fullName": "Paul Marak",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Lakenheath",
+    "warCareer": 0.7
+  },
+  {
+    "playerId": "perezyo01",
+    "fullName": "Yorkis Perez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 0.7
+  },
+  {
+    "playerId": "delgawi01",
+    "fullName": "Wilson Delgado",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.69
+  },
+  {
+    "playerId": "zambred01",
+    "fullName": "Eddie Zambrano",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.69
+  },
+  {
+    "playerId": "martelu01",
+    "fullName": "Luis Marte",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.68
+  },
+  {
+    "playerId": "pemberu01",
+    "fullName": "Rudy Pemberton",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.68
+  },
+  {
+    "playerId": "hernaev01",
+    "fullName": "Evelio Hernandez",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guanabacoa",
+    "warCareer": 0.67
+  },
+  {
+    "playerId": "olivoch01",
+    "fullName": "Chi-Chi Olivo",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guayubin",
+    "warCareer": 0.67
+  },
+  {
+    "playerId": "reachal01",
+    "fullName": "Al Reach",
+    "birthYear": 1840,
+    "birthDecade": 1840,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "London",
+    "warCareer": 0.67
+  },
+  {
+    "playerId": "tavarje01",
+    "fullName": "Jesus Tavarez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.67
+  },
+  {
+    "playerId": "diazvi01",
+    "fullName": "Victor Diaz",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.66
+  },
+  {
+    "playerId": "smithha03",
+    "fullName": "Harry Smith",
+    "birthYear": 1874,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": 0.66
+  },
+  {
+    "playerId": "castial02",
+    "fullName": "Alberto Castillo",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.65
+  },
+  {
+    "playerId": "herreel01",
+    "fullName": "Elian Herrera",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.65
+  },
+  {
+    "playerId": "mccarto03",
+    "fullName": "Tom McCarthy",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Landstuhl",
+    "warCareer": 0.65
+  },
+  {
+    "playerId": "estrele01",
+    "fullName": "Leo Estrella",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": 0.64
+  },
+  {
+    "playerId": "morenju01",
+    "fullName": "Julio Moreno",
+    "birthYear": 1921,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guines",
+    "warCareer": 0.64
+  },
+  {
+    "playerId": "perezbe01",
+    "fullName": "Beltran Perez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 0.64
+  },
+  {
+    "playerId": "rodrilu01",
+    "fullName": "Luis Rodriguez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Carlos",
+    "warCareer": 0.64
+  },
+  {
+    "playerId": "mejiaje01",
+    "fullName": "Jenrry Mejia",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Tabara Arriba",
+    "warCareer": 0.63
+  },
+  {
+    "playerId": "perezan01",
+    "fullName": "Antonio Perez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 0.63
+  },
+  {
+    "playerId": "acostme01",
+    "fullName": "Merito Acosta",
+    "birthYear": 1896,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Bauta",
+    "warCareer": 0.62
+  },
+  {
+    "playerId": "cabrera01",
+    "fullName": "Ramon Cabrera",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.62
+  },
+  {
+    "playerId": "curricl01",
+    "fullName": "Clarence Currie",
+    "birthYear": 1878,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Windsor",
+    "warCareer": 0.62
+  },
+  {
+    "playerId": "bautaed01",
+    "fullName": "Ed Bauta",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Florida",
+    "warCareer": 0.6
+  },
+  {
+    "playerId": "martish01",
+    "fullName": "Shairon Martis",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 0.6
+  },
+  {
+    "playerId": "moraljo02",
+    "fullName": "Jose Morales",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.6
+  },
+  {
+    "playerId": "sanched01",
+    "fullName": "Eduardo Sanchez",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 0.6
+  },
+  {
+    "playerId": "landera01",
+    "fullName": "Rafael Landestoy",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": 0.59
+  },
+  {
+    "playerId": "heredfe01",
+    "fullName": "Felix Heredia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": 0.58
+  },
+  {
+    "playerId": "orrpe01",
+    "fullName": "Pete Orr",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Richmond Hill",
+    "warCareer": 0.58
+  },
+  {
+    "playerId": "rodrica01",
+    "fullName": "Carlos Rodriguez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexico",
+    "warCareer": 0.58
+  },
+  {
+    "playerId": "perazjo01",
+    "fullName": "Jose Peraza",
+    "birthYear": 1994,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barinas",
+    "warCareer": 0.57
+  },
+  {
+    "playerId": "santijo01",
+    "fullName": "Jose Santiago",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Coamo",
+    "warCareer": 0.57
+  },
+  {
+    "playerId": "shawal01",
+    "fullName": "Al Shaw",
+    "birthYear": 1873,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Burslem",
+    "warCareer": 0.57
+  },
+  {
+    "playerId": "flandyo01",
+    "fullName": "Yohan Flande",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": 0.56
+  },
+  {
+    "playerId": "laforty01",
+    "fullName": "Ty LaForest",
+    "birthYear": 1917,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Edmundston",
+    "warCareer": 0.56
+  },
+  {
+    "playerId": "velazca01",
+    "fullName": "Carlos Velazquez",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Loiza",
+    "warCareer": 0.56
+  },
+  {
+    "playerId": "barcelo01",
+    "fullName": "Lorenzo Barcelo",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.55
+  },
+  {
+    "playerId": "colmafr01",
+    "fullName": "Frank Colman",
+    "birthYear": 1918,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 0.55
+  },
+  {
+    "playerId": "diazro01",
+    "fullName": "Robinzon Diaz",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Plata",
+    "warCareer": 0.55
+  },
+  {
+    "playerId": "martijo04",
+    "fullName": "Jose Martinez",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cardenas",
+    "warCareer": 0.55
+  },
+  {
+    "playerId": "pireljo01",
+    "fullName": "Jose Pirela",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valera",
+    "warCareer": 0.54
+  },
+  {
+    "playerId": "takahke01",
+    "fullName": "Ken Takahashi",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Yokohama",
+    "warCareer": 0.53
+  },
+  {
+    "playerId": "jimenda01",
+    "fullName": "D'Angelo Jimenez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.51
+  },
+  {
+    "playerId": "perezlu01",
+    "fullName": "Luis Perez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guayubin",
+    "warCareer": 0.51
+  },
+  {
+    "playerId": "balenwl01",
+    "fullName": "Wladimir Balentien",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 0.5
+  },
+  {
+    "playerId": "escalse01",
+    "fullName": "Sergio Escalona",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tocuyo",
+    "warCareer": 0.5
+  },
+  {
+    "playerId": "heredwi01",
+    "fullName": "Wilson Heredia",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 0.5
+  },
+  {
+    "playerId": "nunezjo02",
+    "fullName": "Jose Nunez",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": 0.5
+  },
+  {
+    "playerId": "beltrri01",
+    "fullName": "Rigo Beltran",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": 0.49
+  },
+  {
+    "playerId": "crespfe01",
+    "fullName": "Felipe Crespo",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.49
+  },
+  {
+    "playerId": "mashoda01",
+    "fullName": "Damon Mashore",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 0.49
+  },
+  {
+    "playerId": "tueroos01",
+    "fullName": "Oscar Tuero",
+    "birthYear": 1893,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.49
+  },
+  {
+    "playerId": "ariasal02",
+    "fullName": "Alberto Arias",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.48
+  },
+  {
+    "playerId": "guzmafr01",
+    "fullName": "Freddy Guzman",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.48
+  },
+  {
+    "playerId": "hughelu01",
+    "fullName": "Luke Hughes",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Perth",
+    "warCareer": 0.48
+  },
+  {
+    "playerId": "bronkje01",
+    "fullName": "Jeff Bronkey",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Afghanistan",
+    "birthCountryRaw": "Afghanistan",
+    "birthCity": "Kabul",
+    "warCareer": 0.47
+  },
+  {
+    "playerId": "guzmage01",
+    "fullName": "Geraldo Guzman",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Tenares",
+    "warCareer": 0.47
+  },
+  {
+    "playerId": "manonju01",
+    "fullName": "Julio Manon",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guerra",
+    "warCareer": 0.47
+  },
+  {
+    "playerId": "silvelu01",
+    "fullName": "Luis Silverio",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Gonzalez",
+    "warCareer": 0.47
+  },
+  {
+    "playerId": "cabrefr01",
+    "fullName": "Francisco Cabrera",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.46
+  },
+  {
+    "playerId": "marticr01",
+    "fullName": "Cristhian Martinez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.46
+  },
+  {
+    "playerId": "moraan01",
+    "fullName": "Andres Mora",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Rio Bravo",
+    "warCareer": 0.46
+  },
+  {
+    "playerId": "pompeda01",
+    "fullName": "Dalton Pompey",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Mississauga",
+    "warCareer": 0.46
+  },
+  {
+    "playerId": "rubiojo01",
+    "fullName": "Jorge Rubio",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexicali",
+    "warCareer": 0.46
+  },
+  {
+    "playerId": "santara01",
+    "fullName": "Rafael Santana",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 0.46
+  },
+  {
+    "playerId": "cortba01",
+    "fullName": "Barry Cort",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 0.45
+  },
+  {
+    "playerId": "krugma01",
+    "fullName": "Marty Krug",
+    "birthYear": 1888,
+    "birthDecade": 1880,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Koblenz",
+    "warCareer": 0.45
+  },
+  {
+    "playerId": "mejiasa01",
+    "fullName": "Sam Mejias",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 0.45
+  },
+  {
+    "playerId": "spencjo01",
+    "fullName": "Josh Spence",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Grovedale",
+    "warCareer": 0.45
+  },
+  {
+    "playerId": "corpoca01",
+    "fullName": "Carlos Corporan",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Hato Rey",
+    "warCareer": 0.44
+  },
+  {
+    "playerId": "depaujo01",
+    "fullName": "Jorge De Paula",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana Grande de Boya",
+    "warCareer": 0.44
+  },
+  {
+    "playerId": "santaju01",
+    "fullName": "Julio Santana",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.44
+  },
+  {
+    "playerId": "escaled01",
+    "fullName": "Edgmer Escalona",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": 0.43
+  },
+  {
+    "playerId": "morenju02",
+    "fullName": "Juan Moreno",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maiquetia",
+    "warCareer": 0.43
+  },
+  {
+    "playerId": "reyesgi01",
+    "fullName": "Gil Reyes",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.43
+  },
+  {
+    "playerId": "carrejo01",
+    "fullName": "Joel Carreno",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.42
+  },
+  {
+    "playerId": "riverlu02",
+    "fullName": "Luis Rivera",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Chihuahua",
+    "warCareer": 0.42
+  },
+  {
+    "playerId": "monasca01",
+    "fullName": "Carlos Monasterios",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Higuerote",
+    "warCareer": 0.41
+  },
+  {
+    "playerId": "shipada01",
+    "fullName": "Dave Shipanoff",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Edmonton",
+    "warCareer": 0.41
+  },
+  {
+    "playerId": "jonesmi01",
+    "fullName": "Mike Jones",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": 0.4
+  },
+  {
+    "playerId": "nolanth01",
+    "fullName": "The Only Nolan",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": 0.4
+  },
+  {
+    "playerId": "perezju02",
+    "fullName": "Juan Perez",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 0.4
+  },
+  {
+    "playerId": "rosaca01",
+    "fullName": "Carlos Rosa",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 0.4
+  },
+  {
+    "playerId": "altampo01",
+    "fullName": "Porfi Altamirano",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Ciudad Dario",
+    "warCareer": 0.39
+  },
+  {
+    "playerId": "bartovi01",
+    "fullName": "Vince Barton",
+    "birthYear": 1908,
+    "birthDecade": 1900,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Edmonton",
+    "warCareer": 0.39
+  },
+  {
+    "playerId": "carmora01",
+    "fullName": "Rafael Carmona",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.39
+  },
+  {
+    "playerId": "jeando01",
+    "fullName": "Domingo Jean",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.39
+  },
+  {
+    "playerId": "martino01",
+    "fullName": "Norberto Martin",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.39
+  },
+  {
+    "playerId": "stockph01",
+    "fullName": "Phil Stockman",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Oldham",
+    "warCareer": 0.39
+  },
+  {
+    "playerId": "cabreal02",
+    "fullName": "Alex Cabrera",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caripito",
+    "warCareer": 0.38
+  },
+  {
+    "playerId": "caminar01",
+    "fullName": "Arquimedes Caminero",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.38
+  },
+  {
+    "playerId": "gervasa01",
+    "fullName": "Sammy Gervacio",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana de la Mar",
+    "warCareer": 0.38
+  },
+  {
+    "playerId": "martica03",
+    "fullName": "Carlos Martinez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Vasquez",
+    "warCareer": 0.38
+  },
+  {
+    "playerId": "mercahe01",
+    "fullName": "Hector Mercado",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Catano",
+    "warCareer": 0.38
+  },
+  {
+    "playerId": "greenbo01",
+    "fullName": "Bob Greenwood",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Cananea",
+    "warCareer": 0.37
+  },
+  {
+    "playerId": "hansade01",
+    "fullName": "Devern Hansack",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Pearl Lagoon",
+    "warCareer": 0.37
+  },
+  {
+    "playerId": "hernaen01",
+    "fullName": "Enzo Hernandez",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valle de Guanape",
+    "warCareer": 0.37
+  },
+  {
+    "playerId": "morenan01",
+    "fullName": "Angel Moreno",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Soledad de Doblado",
+    "warCareer": 0.37
+  },
+  {
+    "playerId": "zardojo01",
+    "fullName": "Jose Zardon",
+    "birthYear": 1923,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.37
+  },
+  {
+    "playerId": "chitrst01",
+    "fullName": "Steve Chitren",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": 0.36
+  },
+  {
+    "playerId": "rivermi02",
+    "fullName": "Mike Rivera",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.36
+  },
+  {
+    "playerId": "salasju01",
+    "fullName": "Juan Salas",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.36
+  },
+  {
+    "playerId": "faluir01",
+    "fullName": "Irving Falu",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Hato Rey",
+    "warCareer": 0.35
+  },
+  {
+    "playerId": "gonzaju01",
+    "fullName": "Julio Gonzalez",
+    "birthYear": 1920,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Banes",
+    "warCareer": 0.35
+  },
+  {
+    "playerId": "prokolu01",
+    "fullName": "Luke Prokopec",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Blackwood",
+    "warCareer": 0.35
+  },
+  {
+    "playerId": "ramirjc01",
+    "fullName": "J. C. Ramirez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Managua",
+    "warCareer": 0.35
+  },
+  {
+    "playerId": "rosarro01",
+    "fullName": "Rodrigo Rosario",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 0.35
+  },
+  {
+    "playerId": "rowanda01",
+    "fullName": "Dave Rowan",
+    "birthYear": 1881,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Elora",
+    "warCareer": 0.35
+  },
+  {
+    "playerId": "gonzalu02",
+    "fullName": "Luis Gonzalez",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "lampake01",
+    "fullName": "Keith Lampard",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Warrington",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "macharo01",
+    "fullName": "Robert Machado",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "martido02",
+    "fullName": "Domingo Martinez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "munozbo01",
+    "fullName": "Bobby Munoz",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "phelpto01",
+    "fullName": "Tommy Phelps",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Seoul",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "rodrito01",
+    "fullName": "Tony Rodriguez",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": 0.34
+  },
+  {
+    "playerId": "barrage01",
+    "fullName": "German Barranca",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Veracruz",
+    "warCareer": 0.33
+  },
+  {
+    "playerId": "marteje01",
+    "fullName": "Jefry Marte",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 0.33
+  },
+  {
+    "playerId": "pickeca01",
+    "fullName": "Calvin Pickering",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": null,
+    "warCareer": 0.33
+  },
+  {
+    "playerId": "salazos01",
+    "fullName": "Oscar Salazar",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 0.33
+  },
+  {
+    "playerId": "tanakke01",
+    "fullName": "Kensuke Tanaka",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Chikushino",
+    "warCareer": 0.33
+  },
+  {
+    "playerId": "bonetju01",
+    "fullName": "Julio Bonetti",
+    "birthYear": 1911,
+    "birthDecade": 1910,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "Genoa",
+    "warCareer": 0.32
+  },
+  {
+    "playerId": "gimenhe01",
+    "fullName": "Hector Gimenez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felipe",
+    "warCareer": 0.32
+  },
+  {
+    "playerId": "ruthejo01",
+    "fullName": "Johnny Rutherford",
+    "birthYear": 1925,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Belleville",
+    "warCareer": 0.32
+  },
+  {
+    "playerId": "sanchro01",
+    "fullName": "Romulo Sanchez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Carora",
+    "warCareer": 0.32
+  },
+  {
+    "playerId": "bellju01",
+    "fullName": "Juan Bell",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.31
+  },
+  {
+    "playerId": "barriyh01",
+    "fullName": "Yhonathan Barrios",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": 0.3
+  },
+  {
+    "playerId": "colomje01",
+    "fullName": "Jesus Colome",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.3
+  },
+  {
+    "playerId": "mercehe01",
+    "fullName": "Henry Mercedes",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.3
+  },
+  {
+    "playerId": "garrigi01",
+    "fullName": "Gil Garrido",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "hattijo01",
+    "fullName": "John Hattig",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Guam",
+    "birthCountryRaw": "Guam",
+    "birthCity": "Tamuning",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "maysoed01",
+    "fullName": "Edwin Maysonet",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "penabr01",
+    "fullName": "Brayan Pena",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "quinolu01",
+    "fullName": "Luis Quinones",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "ramirma03",
+    "fullName": "Max Ramirez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "shielvi01",
+    "fullName": "Vince Shields",
+    "birthYear": 1900,
+    "birthDecade": 1900,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Fredericton",
+    "warCareer": 0.29
+  },
+  {
+    "playerId": "leesa01",
+    "fullName": "Sang-Hoon Lee",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Seoul",
+    "warCareer": 0.27
+  },
+  {
+    "playerId": "ramirhe01",
+    "fullName": "Hector Ramirez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": 0.27
+  },
+  {
+    "playerId": "rlealse01",
+    "fullName": "Sendy Rleal",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.27
+  },
+  {
+    "playerId": "rodrifr04",
+    "fullName": "Francisco Rodriguez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexicali",
+    "warCareer": 0.27
+  },
+  {
+    "playerId": "pinoyo01",
+    "fullName": "Yohan Pino",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Turmero",
+    "warCareer": 0.26
+  },
+  {
+    "playerId": "tadanka01",
+    "fullName": "Kazuhito Tadano",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": 0.26
+  },
+  {
+    "playerId": "diazja01",
+    "fullName": "Jairo Diaz",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto La Cruz",
+    "warCareer": 0.24
+  },
+  {
+    "playerId": "garciam01",
+    "fullName": "Amaury Garcia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.24
+  },
+  {
+    "playerId": "gonzage01",
+    "fullName": "German Gonzalez",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Rio Caribe",
+    "warCareer": 0.24
+  },
+  {
+    "playerId": "kooda01",
+    "fullName": "Dae-Sung Koo",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Daejeon",
+    "warCareer": 0.24
+  },
+  {
+    "playerId": "duranlu01",
+    "fullName": "Luis Durango",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": 0.23
+  },
+  {
+    "playerId": "greenst01",
+    "fullName": "Steve Green",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Greenfield Park",
+    "warCareer": 0.23
+  },
+  {
+    "playerId": "laroqsa01",
+    "fullName": "Sam LaRocque",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. Mathias",
+    "warCareer": 0.23
+  },
+  {
+    "playerId": "machaal01",
+    "fullName": "Alejandro Machado",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.23
+  },
+  {
+    "playerId": "pinedlu01",
+    "fullName": "Luis Pineda",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.23
+  },
+  {
+    "playerId": "adducji02",
+    "fullName": "Jim Adduci",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Burnaby",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "carvama01",
+    "fullName": "Marcos Carvajal",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "francma02",
+    "fullName": "Maikel Franco",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "germego01",
+    "fullName": "Gonzalez Germen",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guaymate",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "longre01",
+    "fullName": "Red Long",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Burlington",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "mcdonke01",
+    "fullName": "Keith McDonald",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Yokosuka",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "tejermi01",
+    "fullName": "Michael Tejera",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.22
+  },
+  {
+    "playerId": "cairnca01",
+    "fullName": "Cameron Cairncross",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Cairns",
+    "warCareer": 0.21
+  },
+  {
+    "playerId": "carides01",
+    "fullName": "Esmailin Caridad",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 0.21
+  },
+  {
+    "playerId": "loch02",
+    "fullName": "Chia-Jen Lo",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Pingtung County",
+    "warCareer": 0.21
+  },
+  {
+    "playerId": "torrean01",
+    "fullName": "Angel Torres",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Cienaga",
+    "warCareer": 0.21
+  },
+  {
+    "playerId": "castrsi01",
+    "fullName": "Simon Castro",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Jose de los Llanos",
+    "warCareer": 0.2
+  },
+  {
+    "playerId": "gonzaeu01",
+    "fullName": "Eusebio Gonzalez",
+    "birthYear": 1892,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.2
+  },
+  {
+    "playerId": "petitgr01",
+    "fullName": "Gregorio Petit",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ocumare del Tuy",
+    "warCareer": 0.2
+  },
+  {
+    "playerId": "roachsk01",
+    "fullName": "Skel Roach",
+    "birthYear": 1871,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Danzig",
+    "warCareer": 0.2
+  },
+  {
+    "playerId": "romerda01",
+    "fullName": "Davis Romero",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Aguadulce",
+    "warCareer": 0.2
+  },
+  {
+    "playerId": "sinclst01",
+    "fullName": "Steve Sinclair",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Victoria",
+    "warCareer": 0.2
+  },
+  {
+    "playerId": "deltomi01",
+    "fullName": "Miguel Del Toro",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Ignacio",
+    "warCareer": 0.19
+  },
+  {
+    "playerId": "diazju03",
+    "fullName": "Jumbo Diaz",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 0.19
+  },
+  {
+    "playerId": "mendead01",
+    "fullName": "Adalberto Mendez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.19
+  },
+  {
+    "playerId": "pinnaed01",
+    "fullName": "Ed Pinnance",
+    "birthYear": 1880,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Walpole Island",
+    "warCareer": 0.19
+  },
+  {
+    "playerId": "cacered01",
+    "fullName": "Edgar Caceres",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 0.18
+  },
+  {
+    "playerId": "gettmja01",
+    "fullName": "Jake Gettman",
+    "birthYear": 1875,
+    "birthDecade": 1870,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "Frank",
+    "warCareer": 0.18
+  },
+  {
+    "playerId": "kylean01",
+    "fullName": "Andy Kyle",
+    "birthYear": 1889,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 0.18
+  },
+  {
+    "playerId": "chrisjo01",
+    "fullName": "Joe Christopher",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Frederiksted",
+    "warCareer": 0.17
+  },
+  {
+    "playerId": "eenhoro01",
+    "fullName": "Robert Eenhoorn",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Rotterdam",
+    "warCareer": 0.17
+  },
+  {
+    "playerId": "iribahe01",
+    "fullName": "Hernan Iribarren",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 0.17
+  },
+  {
+    "playerId": "montema01",
+    "fullName": "Manny Montejo",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Caibarien",
+    "warCareer": 0.17
+  },
+  {
+    "playerId": "ruizch01",
+    "fullName": "Chico Ruiz",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.17
+  },
+  {
+    "playerId": "bocachi01",
+    "fullName": "Hiram Bocachica",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "brachsi01",
+    "fullName": "Silvino Bracho",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "davalyo01",
+    "fullName": "Yo-Yo Davalillo",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cabimas",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "dunnst01",
+    "fullName": "Steve Dunn",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "nunezed02",
+    "fullName": "Eduardo Nunez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "richaan01",
+    "fullName": "Antoan Richardson",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Bahamas",
+    "birthCountryRaw": "Bahamas",
+    "birthCity": "Nassau",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "rodried04",
+    "fullName": "Eddy Rodriguez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Villa Clara",
+    "warCareer": 0.16
+  },
+  {
+    "playerId": "gorbogl01",
+    "fullName": "Glen Gorbous",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Drumheller",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "guzmasa01",
+    "fullName": "Santiago Guzman",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "leonsa01",
+    "fullName": "Sandy Leon",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "morenor01",
+    "fullName": "Orber Moreno",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "penael01",
+    "fullName": "Elvis Pena",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "robleos01",
+    "fullName": "Oscar Robles",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "roomero01",
+    "fullName": "Rolando Roomes",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Jamaica",
+    "birthCountryRaw": "Jamaica",
+    "birthCity": "Kingston",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "ruizch02",
+    "fullName": "Chico Ruiz",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "sotogi01",
+    "fullName": "Giovanni Soto",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Carolina",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "vargaed01",
+    "fullName": "Eddie Vargas",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guanica",
+    "warCareer": 0.15
+  },
+  {
+    "playerId": "armasma01",
+    "fullName": "Marcos Armas",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Piritu",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "nifu01",
+    "fullName": "Fu-Te Ni",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Pingtung County",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "ogandne01",
+    "fullName": "Nefi Ogando",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "ruanwi01",
+    "fullName": "Wilkin Ruan",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guaymate",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "simonra01",
+    "fullName": "Randall Simon",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "trevibo01",
+    "fullName": "Bobby Trevino",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monterrey",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "villabr02",
+    "fullName": "Brayan Villarreal",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": 0.14
+  },
+  {
+    "playerId": "burnsja01",
+    "fullName": "Jack Burns",
+    "birthYear": 1878,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Salford",
+    "warCareer": 0.13
+  },
+  {
+    "playerId": "garciha01",
+    "fullName": "Harvey Garcia",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.13
+  },
+  {
+    "playerId": "harribi03",
+    "fullName": "Bill Harris",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Duguayville",
+    "warCareer": 0.13
+  },
+  {
+    "playerId": "hopkimi01",
+    "fullName": "Mike Hopkins",
+    "birthYear": 1872,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Glasgow",
+    "warCareer": 0.13
+  },
+  {
+    "playerId": "kashita01",
+    "fullName": "Takashi Kashiwada",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Yashiro",
+    "warCareer": 0.13
+  },
+  {
+    "playerId": "sosajo01",
+    "fullName": "Jose Sosa",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.13
+  },
+  {
+    "playerId": "garbeba01",
+    "fullName": "Barbaro Garbey",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": 0.12
+  },
+  {
+    "playerId": "lisiri01",
+    "fullName": "Rick Lisi",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Halifax",
+    "warCareer": 0.12
+  },
+  {
+    "playerId": "penaan01",
+    "fullName": "Angel Pena",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.12
+  },
+  {
+    "playerId": "ramosch01",
+    "fullName": "Chucho Ramos",
+    "birthYear": 1918,
+    "birthDecade": 1910,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maturin",
+    "warCareer": 0.12
+  },
+  {
+    "playerId": "beltren01",
+    "fullName": "Engel Beltre",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.11
+  },
+  {
+    "playerId": "garcigu01",
+    "fullName": "Guillermo Garcia",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": 0.11
+  },
+  {
+    "playerId": "garcijo01",
+    "fullName": "Jose Garcia",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Dajabon",
+    "warCareer": 0.11
+  },
+  {
+    "playerId": "pegueca01",
+    "fullName": "Carlos Peguero",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hondo Valle",
+    "warCareer": 0.11
+  },
+  {
+    "playerId": "remmewi01",
+    "fullName": "Win Remmerswaal",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "The Hague",
+    "warCareer": 0.11
+  },
+  {
+    "playerId": "whitesa01",
+    "fullName": "Sam White",
+    "birthYear": 1893,
+    "birthDecade": 1890,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Kinsley",
+    "warCareer": 0.11
+  },
+  {
+    "playerId": "alberan01",
+    "fullName": "Andrew Albers",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "North Battleford",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "buxtora01",
+    "fullName": "Ralph Buxton",
+    "birthYear": 1911,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Weyburn",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "diazju01",
+    "fullName": "Juan Diaz",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "San Jose de las Lajas",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "galveba01",
+    "fullName": "Balvino Galvez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "loisal01",
+    "fullName": "Alberto Lois",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "martihe02",
+    "fullName": "Hector Martinez",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Villas",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "morriak01",
+    "fullName": "Akeel Morris",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": null,
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "riverca02",
+    "fullName": "Carlos Rivero",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "shankha01",
+    "fullName": "Harvey Shank",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 0.1
+  },
+  {
+    "playerId": "abreuju01",
+    "fullName": "Juan Abreu",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "alvarda02",
+    "fullName": "Dariel Alvarez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Camaguey",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "delarto01",
+    "fullName": "Tomas de la Rosa",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Victoria",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "demarfr01",
+    "fullName": "Fred Demarais",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "maesthe01",
+    "fullName": "Hector Maestri",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "mesame01",
+    "fullName": "Melky Mesa",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "morelra01",
+    "fullName": "Ramon Morel",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Gonzalez",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "stoneto01",
+    "fullName": "Tobi Stoner",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Landstuhl",
+    "warCareer": 0.09
+  },
+  {
+    "playerId": "castran01",
+    "fullName": "Angel Castro",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Pimentel",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "corcida01",
+    "fullName": "Daniel Corcino",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "floreke01",
+    "fullName": "Kendry Flores",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "fordwe01",
+    "fullName": "Wenty Ford",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Bahamas",
+    "birthCountryRaw": "Bahamas",
+    "birthCity": "Nassau",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "martiwi01",
+    "fullName": "Willie Martinez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "morrijo03",
+    "fullName": "Jon Morrison",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "ramosbo01",
+    "fullName": "Bobby Ramos",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Calabazar de Sagua",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "rodriwi02",
+    "fullName": "Wilking Rodriguez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": 0.08
+  },
+  {
+    "playerId": "garcilu02",
+    "fullName": "Luis Garcia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Hermosillo",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "gonzadi01",
+    "fullName": "Dicky Gonzalez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "ibarred01",
+    "fullName": "Edgar Ibarra",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "isaleor01",
+    "fullName": "Orlando Isales",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "merceme01",
+    "fullName": "Melvin Mercedes",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "vallehe01",
+    "fullName": "Hector Valle",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vega Baja",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "vasqura01",
+    "fullName": "Rafael Vasquez",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "willigl01",
+    "fullName": "Glenn Williams",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Gosford",
+    "warCareer": 0.07
+  },
+  {
+    "playerId": "canatwi01",
+    "fullName": "Willie Canate",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Bobures",
+    "warCareer": 0.06
+  },
+  {
+    "playerId": "lazora01",
+    "fullName": "Raudel Lazo",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": 0.06
+  },
+  {
+    "playerId": "ordento01",
+    "fullName": "Tony Ordenana",
+    "birthYear": 1918,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guanabacoa",
+    "warCareer": 0.06
+  },
+  {
+    "playerId": "septile01",
+    "fullName": "Leyson Septimo",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.06
+  },
+  {
+    "playerId": "uguetlu01",
+    "fullName": "Luis Ugueto",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.06
+  },
+  {
+    "playerId": "aucoide01",
+    "fullName": "Derek Aucoin",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Lachine",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "batisra01",
+    "fullName": "Rafael Batista",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "bierdra01",
+    "fullName": "Randor Bierd",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "britoeu01",
+    "fullName": "Eude Brito",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana de la Mar",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "cedajo01",
+    "fullName": "Jose Ceda",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "cuetoma01",
+    "fullName": "Manuel Cueto",
+    "birthYear": 1892,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guanajay",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "depaujo02",
+    "fullName": "Jose De Paula",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "gonzala02",
+    "fullName": "Lariel Gonzalez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "herrejo01",
+    "fullName": "Jose Herrera",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Lorenzo",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "izquiha01",
+    "fullName": "Hank Izquierdo",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Matanzas",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "laraju01",
+    "fullName": "Juan Lara",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "moraljo01",
+    "fullName": "Jose Morales",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Frederiksted",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "serraal01",
+    "fullName": "Alex Serrano",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "socolmi01",
+    "fullName": "Miguel Socolovich",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": 0.05
+  },
+  {
+    "playerId": "bernica01",
+    "fullName": "Carlos Bernier",
+    "birthYear": 1927,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Juana Diaz",
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "flynnmi01",
+    "fullName": "Mike Flynn",
+    "birthYear": 1872,
+    "birthDecade": 1870,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "hernaca01",
+    "fullName": "Carlos Hernandez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felix",
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "jimenel01",
+    "fullName": "Elvio Jimenez",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "koukajo01",
+    "fullName": "Joe Koukalik",
+    "birthYear": 1880,
+    "birthDecade": 1880,
+    "birthCountry": "Austria",
+    "birthCountryRaw": "Austria",
+    "birthCity": null,
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "liddial01",
+    "fullName": "Alex Liddi",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "Sanremo",
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "oterore01",
+    "fullName": "Reggie Otero",
+    "birthYear": 1915,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "sanchra01",
+    "fullName": "Raul Sanchez",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Marianao",
+    "warCareer": 0.04
+  },
+  {
+    "playerId": "chavene01",
+    "fullName": "Nestor Chavez",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Chacao",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "estrafr01",
+    "fullName": "Frank Estrada",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Navojoa",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "hernato01",
+    "fullName": "Toby Hernandez",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Calabozo",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "herreal01",
+    "fullName": "Alex Herrera",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "lindsax01",
+    "fullName": "Axel Lindstrom",
+    "birthYear": 1895,
+    "birthDecade": 1890,
+    "birthCountry": "Sweden",
+    "birthCountryRaw": "Sweden",
+    "birthCity": "Gustavsberg",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "lough01",
+    "fullName": "Patrick O'Loughlin",
+    "birthYear": 1860,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "phippde01",
+    "fullName": "Denis Phipps",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "routcph01",
+    "fullName": "Phil Routcliffe",
+    "birthYear": 1870,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Frontenac",
+    "warCareer": 0.03
+  },
+  {
+    "playerId": "boscajc01",
+    "fullName": "J. C. Boscan",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "cookea01",
+    "fullName": "Earl Cook",
+    "birthYear": 1908,
+    "birthDecade": 1900,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Stouffville",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "currepe01",
+    "fullName": "John Curran",
+    "birthYear": 1852,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "fuentmi01",
+    "fullName": "Miguel Fuentes",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Loiza Aldea",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "gilgahu01",
+    "fullName": "Hugh Gilgan",
+    "birthYear": 1852,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "rosarsa01",
+    "fullName": "Santiago Rosario",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guayanilla",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "summeki01",
+    "fullName": "Kid Summers",
+    "birthYear": 1868,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "valdera02",
+    "fullName": "Raul Valdes",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "villahe02",
+    "fullName": "Henry Villar",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": 0.02
+  },
+  {
+    "playerId": "delgaje01",
+    "fullName": "Jesus Delgado",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "gonzami04",
+    "fullName": "Miguel Gonzalez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Porlamar",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "martima02",
+    "fullName": "Manny Martinez",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "millira02",
+    "fullName": "Ralph Milliard",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "perezeu01",
+    "fullName": "Eury Perez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Luis",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "sanchhu01",
+    "fullName": "Humberto Sanchez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "scanlpa01",
+    "fullName": "Pat Scanlon",
+    "birthYear": 1861,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Halifax",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "severat01",
+    "fullName": "Atahualpa Severino",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "tsaoch01",
+    "fullName": "Chin-hui Tsao",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Hualien",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "woerljo01",
+    "fullName": "Joe Woerlin",
+    "birthYear": 1864,
+    "birthDecade": 1860,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": "Trenheim",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "wrighji01",
+    "fullName": "Jim Wright",
+    "birthYear": 1900,
+    "birthDecade": 1900,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Hyde",
+    "warCareer": 0.01
+  },
+  {
+    "playerId": "cerroju01",
+    "fullName": "Juan Cerros",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monterrey",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "escobjo01",
+    "fullName": "Jose Escobar",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Sabana",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "garabed01",
+    "fullName": "Eddy Garabito",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "hannipa01",
+    "fullName": "Pat Hannivan",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Halifax",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "hernach01",
+    "fullName": "Chico Hernandez",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "jonesbi02",
+    "fullName": "Bill Jones",
+    "birthYear": 1887,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hartland",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "larayo01",
+    "fullName": "Yovanny Lara",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "petagro01",
+    "fullName": "Roberto Petagine",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "robinch02",
+    "fullName": "Chris Robinson",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "roblema01",
+    "fullName": "Mauricio Robles",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "sanchce01",
+    "fullName": "Celerino Sanchez",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "El Guayabal",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "valdeca02",
+    "fullName": "Carlos Valderrama",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Bachaquero",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "wingoed01",
+    "fullName": "Ed Wingo",
+    "birthYear": 1895,
+    "birthDecade": 1890,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Ste. Anne de Bellevue",
+    "warCareer": -0.01
+  },
+  {
+    "playerId": "alfonel01",
+    "fullName": "Eliezer Alfonzo",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto La Cruz",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "difowi01",
+    "fullName": "Wilmer Difo",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago de los Caballeros",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "gomezje01",
+    "fullName": "Jeanmar Gomez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "guerrma01",
+    "fullName": "Mario Guerrero",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "heubege01",
+    "fullName": "George Heubel",
+    "birthYear": 1849,
+    "birthDecade": 1840,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "miranju01",
+    "fullName": "Juan Miranda",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Consolacion del Sur",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "munozno01",
+    "fullName": "Noe Munoz",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "ortegjo01",
+    "fullName": "Jose Ortega",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caja Seca",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "perezju01",
+    "fullName": "Juan Perez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Rivas",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "rodriro02",
+    "fullName": "Rosario Rodriguez",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "stanscr01",
+    "fullName": "Craig Stansberry",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Saudi Arabia",
+    "birthCountryRaw": "Saudi Arabia",
+    "birthCity": "Dammam",
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "sullite01",
+    "fullName": "Ted Sullivan",
+    "birthYear": 1851,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.02
+  },
+  {
+    "playerId": "acosted01",
+    "fullName": "Ed Acosta",
+    "birthYear": 1944,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Boquete",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "albagi01",
+    "fullName": "Gibson Alba",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "boldch01",
+    "fullName": "Charlie Bold",
+    "birthYear": 1894,
+    "birthDecade": 1890,
+    "birthCountry": "Sweden",
+    "birthCountryRaw": "Sweden",
+    "birthCity": "Karlskrona",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "campusi01",
+    "fullName": "Sil Campusano",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "delgapu01",
+    "fullName": "Puchy Delgado",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Hatillo",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "ewingre01",
+    "fullName": "Reuben Ewing",
+    "birthYear": 1899,
+    "birthDecade": 1890,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "Odessa",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "gonzajo02",
+    "fullName": "Jose Gonzalez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "gouzzcl01",
+    "fullName": "Claude Gouzzie",
+    "birthYear": 1873,
+    "birthDecade": 1870,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": null,
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "harrito01",
+    "fullName": "Tom Harrison",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Trail",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "limch01",
+    "fullName": "Chang-Yong Lim",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Gwangju",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "mackeer01",
+    "fullName": "Eric MacKenzie",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Glendon",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "magalev01",
+    "fullName": "Ever Magallanes",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "El Sauz",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "navaros01",
+    "fullName": "Oswaldo Navarro",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Villa de Cura",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "novoaro01",
+    "fullName": "Roberto Novoa",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "pegueju01",
+    "fullName": "Julio Peguero",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Isidro",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "riverro01",
+    "fullName": "Roberto Rivera",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "stewaan01",
+    "fullName": "Andy Stewart",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Oshawa",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "urdanli01",
+    "fullName": "Lino Urdaneta",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "valdero01",
+    "fullName": "Roy Valdes",
+    "birthYear": 1920,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "velanjo01",
+    "fullName": "Jorge Velandia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.03
+  },
+  {
+    "playerId": "ardizru01",
+    "fullName": "Rugger Ardizoia",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "Oleggio",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "cabreal01",
+    "fullName": "Al Cabrera",
+    "birthYear": 1881,
+    "birthDecade": 1880,
+    "birthCountry": "Spain",
+    "birthCountryRaw": "Spain",
+    "birthCity": null,
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "collawi01",
+    "fullName": "Willie Collazo",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Carolina",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "garcefr01",
+    "fullName": "Frank Garces",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "garcian01",
+    "fullName": "Anderson Garcia",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "kingmha01",
+    "fullName": "Harry Kingman",
+    "birthYear": 1892,
+    "birthDecade": 1890,
+    "birthCountry": "China",
+    "birthCountryRaw": "China",
+    "birthCity": "Tientsin",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "klozana01",
+    "fullName": "Nap Kloza",
+    "birthYear": 1903,
+    "birthDecade": 1900,
+    "birthCountry": "Poland",
+    "birthCountryRaw": "Poland",
+    "birthCity": null,
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "koringe01",
+    "fullName": "George Korince",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Ottawa",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "lewisal01",
+    "fullName": "Allan Lewis",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "lopezjo02",
+    "fullName": "Jorge Lopez",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Cayey",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "marquis01",
+    "fullName": "Isidro Marquez",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Navojoa",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "martipa03",
+    "fullName": "Pablo Martinez",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana Grande de Boya",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "millebi01",
+    "fullName": "Bill Miller",
+    "birthYear": 1879,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Bad Schwalbach",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "montara01",
+    "fullName": "Rafael Montalvo",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "oeltjtr01",
+    "fullName": "Trent Oeltjen",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "rodriru01",
+    "fullName": "Ruben Rodriguez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cabrera",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "roquera01",
+    "fullName": "Rafael Roque",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "rosarji01",
+    "fullName": "Jimmy Rosario",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "suarelu01",
+    "fullName": "Luis Suarez",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Alto Songo",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "suerowi01",
+    "fullName": "William Suero",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "troybu01",
+    "fullName": "Bun Troy",
+    "birthYear": 1888,
+    "birthDecade": 1880,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Bad Wurzach",
+    "warCareer": -0.04
+  },
+  {
+    "playerId": "cabrace01",
+    "fullName": "Cesar Cabral",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana Grande de Palenque",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "calzana01",
+    "fullName": "Napoleon Calzado",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "colinal01",
+    "fullName": "Alvin Colina",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "fermira01",
+    "fullName": "Ramon Fermin",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "figuepe01",
+    "fullName": "Pedro Figueroa",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "fontwi01",
+    "fullName": "Wilmer Font",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "heredub01",
+    "fullName": "Ubaldo Heredia",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "hernayo01",
+    "fullName": "Yoel Hernandez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "lunahe01",
+    "fullName": "Hector Luna",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "mendomi01",
+    "fullName": "Minnie Mendoza",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Ceiba del Agua",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "monteag01",
+    "fullName": "Agustin Montero",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "motada01",
+    "fullName": "Danny Mota",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "ortegbi01",
+    "fullName": "Bill Ortega",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "perazlu01",
+    "fullName": "Luis Peraza",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "reyesjo02",
+    "fullName": "Jose Reyes",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "rodried02",
+    "fullName": "Edwin Rodriguez",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "rosarsa02",
+    "fullName": "Sandy Rosario",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Salcedo",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "santama01",
+    "fullName": "Marino Santana",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Los Llanos",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "sullibi01",
+    "fullName": "Bill Sullivan",
+    "birthYear": 1853,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "valdere01",
+    "fullName": "Rene Valdes",
+    "birthYear": 1929,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guanabacoa",
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "zapusjo01",
+    "fullName": "Joe Zapustas",
+    "birthYear": 1907,
+    "birthDecade": 1900,
+    "birthCountry": "Lithuania",
+    "birthCountryRaw": "Lithuania",
+    "birthCity": null,
+    "warCareer": -0.05
+  },
+  {
+    "playerId": "alvarcl01",
+    "fullName": "Clemente Alvarez",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guanta",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "blancda01",
+    "fullName": "Damaso Blanco",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Curiepe",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "blanche01",
+    "fullName": "Henry Blanco",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "bravoan01",
+    "fullName": "Angel Bravo",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "cabrejo02",
+    "fullName": "Jolbert Cabrera",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "decasyu01",
+    "fullName": "Yurendell de Caster",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Brevengat",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "dykhora01",
+    "fullName": "Radhames Dykhoff",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Aruba",
+    "birthCountryRaw": "Aruba",
+    "birthCity": "Paradera",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "escalfe01",
+    "fullName": "Felix Escalona",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "gomezpr01",
+    "fullName": "Preston Gomez",
+    "birthYear": 1923,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Central Preston",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "lakefr01",
+    "fullName": "Fred Lake",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Cornwallis",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "leech01",
+    "fullName": "C. C. Lee",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Peng-Hu County",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "matavi01",
+    "fullName": "Victor Mata",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "perezmi02",
+    "fullName": "Miguel Perez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "rochear01",
+    "fullName": "Armando Roche",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "rodried03",
+    "fullName": "Eddy Rodriguez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "rosarvi01",
+    "fullName": "Victor Rosario",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "stpiema01",
+    "fullName": "Max St. Pierre",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Quebec",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "tejadwi01",
+    "fullName": "Wilfredo Tejada",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.06
+  },
+  {
+    "playerId": "barrima01",
+    "fullName": "Manuel Barrios",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Cabecera",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "chench01",
+    "fullName": "Chin-Feng Chen",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Tainan City",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "clappst01",
+    "fullName": "Stubby Clapp",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Windsor",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "cruzto01",
+    "fullName": "Tommy Cruz",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arroyo",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "davidbo01",
+    "fullName": "Bob Davidson",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Bad Kurznach",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "lelivbi01",
+    "fullName": "Bill Lelivelt",
+    "birthYear": 1884,
+    "birthDecade": 1880,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": null,
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "linch01",
+    "fullName": "Che-Hsuan Lin",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Hwa-Lian",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "linhaca01",
+    "fullName": "Carl Linhart",
+    "birthYear": 1929,
+    "birthDecade": 1920,
+    "birthCountry": "Czech Republic",
+    "birthCountryRaw": "Czech Republic",
+    "birthCity": "Zborov",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "maysema01",
+    "fullName": "Matt Maysey",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "michajo01",
+    "fullName": "John Michaelson",
+    "birthYear": 1893,
+    "birthDecade": 1890,
+    "birthCountry": "Finland",
+    "birthCountryRaw": "Finland",
+    "birthCity": "Tivalkoski",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "olivele01",
+    "fullName": "Lester Oliveros",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "pulidal01",
+    "fullName": "Alfonso Pulido",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tierra Blanca",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "smithfr01",
+    "fullName": "Frank Smith",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Fonthill",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "tartajo01",
+    "fullName": "Jose Tartabull",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cienfuegos",
+    "warCareer": -0.07
+  },
+  {
+    "playerId": "andruwi01",
+    "fullName": "Wyman Andrus",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Orono",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "comeljo01",
+    "fullName": "Jorge Comellas",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "delosra01",
+    "fullName": "Ramon de los Santos",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "leutz01",
+    "fullName": "David Lenz",
+    "birthYear": 1851,
+    "birthDecade": 1850,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "maldoca03",
+    "fullName": "Carlos Maldonado",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "manonra01",
+    "fullName": "Ramon Manon",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "ramirsa01",
+    "fullName": "Santiago Ramirez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "saloman01",
+    "fullName": "Angel Salome",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "sanchfe01",
+    "fullName": "Felix Sanchez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "schlidu01",
+    "fullName": "Dutch Schliebner",
+    "birthYear": 1891,
+    "birthDecade": 1890,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Berlin",
+    "warCareer": -0.08
+  },
+  {
+    "playerId": "delgaal01",
+    "fullName": "Alex Delgado",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Palmarejo",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "gonzaor01",
+    "fullName": "Orlando Gonzalez",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "hoype01",
+    "fullName": "Peter Hoy",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Brockville",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "josepri01",
+    "fullName": "Rick Joseph",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "ostrobr01",
+    "fullName": "Brian Ostrosser",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "peplohe01",
+    "fullName": "Henry Peploski",
+    "birthYear": 1905,
+    "birthDecade": 1900,
+    "birthCountry": "Poland",
+    "birthCountryRaw": "Poland",
+    "birthCity": "Garlin",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "randost01",
+    "fullName": "Steve Randolph",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Okinawa",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "rodrigu01",
+    "fullName": "Guillermo Rodriguez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "sanchhe01",
+    "fullName": "Hector Sanchez",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "smithto01",
+    "fullName": "Tom Smith",
+    "birthYear": 1851,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Guelph",
+    "warCareer": -0.09
+  },
+  {
+    "playerId": "amorvi01",
+    "fullName": "Vicente Amor",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "bellira01",
+    "fullName": "Rafael Belliard",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Pueblo Nuevo",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "casimca01",
+    "fullName": "Carlos Casimiro",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "duranro01",
+    "fullName": "Roberto Duran",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Moca",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "herredi01",
+    "fullName": "Dilson Herrera",
+    "birthYear": 1994,
+    "birthDecade": 1990,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "lawreji01",
+    "fullName": "Jim Lawrence",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "leoniz01",
+    "fullName": "Izzy Leon",
+    "birthYear": 1911,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cruces",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "nunezjh01",
+    "fullName": "Jhonny Nunez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Jose de las Matas",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "santaan01",
+    "fullName": "Andres Santana",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "thakeal01",
+    "fullName": "Al Thake",
+    "birthYear": 1849,
+    "birthDecade": 1840,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Wymondham",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "tolenjo01",
+    "fullName": "Jose Tolentino",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexico",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "toppiru01",
+    "fullName": "Rupe Toppin",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": -0.1
+  },
+  {
+    "playerId": "cruziv01",
+    "fullName": "Ivan Cruz",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "fitzgde01",
+    "fullName": "Dennis Fitzgerald",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "gaisefr01",
+    "fullName": "Fred Gaiser",
+    "birthYear": 1885,
+    "birthDecade": 1880,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Stuttgart",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "gomezhe01",
+    "fullName": "Hector Gomez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "hernalu01",
+    "fullName": "Luis Hernandez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Quibor",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "izquiha02",
+    "fullName": "Hansel Izquierdo",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "jimenju01",
+    "fullName": "Juan Jimenez",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Torre",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "leonar01",
+    "fullName": "Arnold Leon",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Culiacan",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "martijo06",
+    "fullName": "Jose Martinez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guayubin",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "navarre01",
+    "fullName": "Rey Navarro",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "ramirwi01",
+    "fullName": "Wilkin Ramirez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "santofr01",
+    "fullName": "Francisco Santos",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "saturlu01",
+    "fullName": "Luis Saturria",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "urruthe01",
+    "fullName": "Henry Urrutia",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Tunas",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "valdepe01",
+    "fullName": "Pedro Valdes",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "verasda01",
+    "fullName": "Dario Veras",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.11
+  },
+  {
+    "playerId": "arojo01",
+    "fullName": "Jonathan Aro",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Vega",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "blacktr01",
+    "fullName": "Travis Blackley",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Melbourne",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "carliwa01",
+    "fullName": "Walter Carlisle",
+    "birthYear": 1881,
+    "birthDecade": 1880,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "lopezra01",
+    "fullName": "Ramon Lopez",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Villas",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "morened01",
+    "fullName": "Edwin Moreno",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Mojan",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "penaar01",
+    "fullName": "Ariel Pena",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Los Jovillos",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "rodrigu02",
+    "fullName": "Guilder Rodriguez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "santora01",
+    "fullName": "Rafael Santo Domingo",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Orocovis",
+    "warCareer": -0.12
+  },
+  {
+    "playerId": "armbred01",
+    "fullName": "Ed Armbrister",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Bahamas",
+    "birthCountryRaw": "Bahamas",
+    "birthCity": "Nassau",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "avilera01",
+    "fullName": "Ramon Aviles",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Manati",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "delatjo01",
+    "fullName": "Jose De La Torre",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "dortame01",
+    "fullName": "Melvin Dorta",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "garcile01",
+    "fullName": "Leo Garcia",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "morendi01",
+    "fullName": "Diego Moreno",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Higuerote",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "oxsprch01",
+    "fullName": "Chris Oxspring",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Ipswich",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "ramirel02",
+    "fullName": "Elvin Ramirez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "valenbe01",
+    "fullName": "Benny Valenzuela",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": -0.13
+  },
+  {
+    "playerId": "alvarto01",
+    "fullName": "Tony Alvarez",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "goldsiz01",
+    "fullName": "Izzy Goldstein",
+    "birthYear": 1908,
+    "birthDecade": 1900,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "Odessa",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "gomezma01",
+    "fullName": "Mauro Gomez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "hasnepe01",
+    "fullName": "Pete Hasney",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "hernami01",
+    "fullName": "Michel Hernandez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "housecr01",
+    "fullName": "Craig House",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Okinawa",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "huntebi01",
+    "fullName": "Bill Hunter",
+    "birthYear": 1855,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. Thomas",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "librafr01",
+    "fullName": "Frankie Libran",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "luname01",
+    "fullName": "Memo Luna",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexico",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "pedroch01",
+    "fullName": "Chick Pedroes",
+    "birthYear": 1869,
+    "birthDecade": 1860,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "rodriwi01",
+    "fullName": "Wilfredo Rodriguez",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "rosarme01",
+    "fullName": "Melvin Rosario",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "suzukma01",
+    "fullName": "Mac Suzuki",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kobe",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "tocajo01",
+    "fullName": "Jorge Toca",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Remedios",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "velazfr01",
+    "fullName": "Freddie Velazquez",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "villeis01",
+    "fullName": "Ismael Villegas",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.14
+  },
+  {
+    "playerId": "bouchde01",
+    "fullName": "Denis Boucher",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "bowieji01",
+    "fullName": "Jim Bowie",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "campofr01",
+    "fullName": "Frank Campos",
+    "birthYear": 1924,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "fernach02",
+    "fullName": "Chico Fernandez",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "gonzami05",
+    "fullName": "Miguel Gonzalez",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "gonzavi01",
+    "fullName": "Vince Gonzales",
+    "birthYear": 1925,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Quivican",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "hardyal01",
+    "fullName": "Alex Hardy",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "harmabr01",
+    "fullName": "Brad Harman",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Melbourne",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "hernaan01",
+    "fullName": "Anderson Hernandez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "kilkemi01",
+    "fullName": "Mike Kilkenny",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Bradford",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "magnutr01",
+    "fullName": "Trystan Magnuson",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "matospa01",
+    "fullName": "Pascual Matos",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "pulidca01",
+    "fullName": "Carlos Pulido",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "ramosed01",
+    "fullName": "Edgar Ramos",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "rodrihe04",
+    "fullName": "Henry Rodriguez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "torreri01",
+    "fullName": "Ricardo Torres",
+    "birthYear": 1891,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Regla",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "violape01",
+    "fullName": "Pedro Viola",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Juan de la Maguana",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "zaratma01",
+    "fullName": "Mauro Zarate",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": -0.15
+  },
+  {
+    "playerId": "bautijo01",
+    "fullName": "Jose Bautista",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "castrra02",
+    "fullName": "Ramon Castro",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "cristbi01",
+    "fullName": "Bill Cristall",
+    "birthYear": 1875,
+    "birthDecade": 1870,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "Odessa",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "deesh01",
+    "fullName": "Shorty Dee",
+    "birthYear": 1889,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Halifax",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "deinipe01",
+    "fullName": "Pep Deininger",
+    "birthYear": 1877,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Wasseralfingen",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "erautjo01",
+    "fullName": "Joe Erautt",
+    "birthYear": 1921,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vibank",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "farmebi01",
+    "fullName": "Bill Farmer",
+    "birthYear": 1864,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Dublin",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "housejo01",
+    "fullName": "John Houseman",
+    "birthYear": 1870,
+    "birthDecade": 1870,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": null,
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "markedu01",
+    "fullName": "Duke Markell",
+    "birthYear": 1923,
+    "birthDecade": 1920,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": "Paris",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "mcguijo01",
+    "fullName": "John McGuinness",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "mclauba01",
+    "fullName": "Barney McLaughlin",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "palacvi01",
+    "fullName": "Vicente Palacios",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Manlio Fabio Altamirano",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "penaje01",
+    "fullName": "Jesus Pena",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "quintlu01",
+    "fullName": "Luis Quintana",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vega Baja",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "santoan01",
+    "fullName": "Angel Santos",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "sosaju01",
+    "fullName": "Juan Sosa",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "stedrjo01",
+    "fullName": "John Stedronsky",
+    "birthYear": 1850,
+    "birthDecade": 1850,
+    "birthCountry": "Czech Republic",
+    "birthCountryRaw": "Czech Republic",
+    "birthCity": null,
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "weberjo01",
+    "fullName": "Joe Weber",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.16
+  },
+  {
+    "playerId": "alvarda01",
+    "fullName": "Dario Alvarez",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "belloed01",
+    "fullName": "Edwin Bellorin",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felix",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "campole01",
+    "fullName": "Leonel Campos",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valera",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "castiju02",
+    "fullName": "Juan Castillo",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "cotahu01",
+    "fullName": "Humberto Cota",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Luis Rio Colorado",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "deleojo02",
+    "fullName": "Jorge De Leon",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Vega",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "doyleco01",
+    "fullName": "Conny Doyle",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "garatvi01",
+    "fullName": "Victor Garate",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "romerni01",
+    "fullName": "Niuman Romero",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "torreei01",
+    "fullName": "Eider Torres",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "vadebge01",
+    "fullName": "Gene Vadeboncoeur",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Louiseville",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "zimmebi01",
+    "fullName": "Bill Zimmerman",
+    "birthYear": 1887,
+    "birthDecade": 1880,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Kengen",
+    "warCareer": -0.17
+  },
+  {
+    "playerId": "butlero01",
+    "fullName": "Rob Butler",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "East York",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "garciad01",
+    "fullName": "Adonis Garcia",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Ciego de Avila",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "gonzara01",
+    "fullName": "Raul Gonzalez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "joaquwa01",
+    "fullName": "Waldis Joaquin",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Vega",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "lindssh01",
+    "fullName": "Shane Lindsay",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Melbourne",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "naranch01",
+    "fullName": "Cholly Naranjo",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "oxleyhe01",
+    "fullName": "Henry Oxley",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Covehead",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "reidbi01",
+    "fullName": "Billy Reid",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "torredi01",
+    "fullName": "Dilson Torres",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Sur Edo Aragua",
+    "warCareer": -0.18
+  },
+  {
+    "playerId": "beruman01",
+    "fullName": "Andres Berumen",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "castiwi01",
+    "fullName": "Wilkin Castillo",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "coffiiv01",
+    "fullName": "Ivanon Coffie",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "coloncr01",
+    "fullName": "Cris Colon",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "diazjo01",
+    "fullName": "Jose Diaz",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "figuelu01",
+    "fullName": "Luis Figueroa",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "garcira01",
+    "fullName": "Ramon Garcia",
+    "birthYear": 1924,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Esperanza",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "rodriyo01",
+    "fullName": "Yorman Rodriguez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ocumare de la Costa",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "sandofr01",
+    "fullName": "Freddy Sandoval",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "villaed01",
+    "fullName": "Eduardo Villacis",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.19
+  },
+  {
+    "playerId": "ariasru01",
+    "fullName": "Rudy Arias",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Villas",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "burgeto01",
+    "fullName": "Tom Burgess",
+    "birthYear": 1927,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "cocopa01",
+    "fullName": "Pasqual Coco",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "fortuba01",
+    "fullName": "Bartolome Fortunato",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "jaimeju01",
+    "fullName": "Juan Jaime",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "lopezar02",
+    "fullName": "Arturo Lopez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Culiacan",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "lunarfe01",
+    "fullName": "Fernando Lunar",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cantaura",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "mcmilge01",
+    "fullName": "George McMillan",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "morenjo01",
+    "fullName": "Jose Moreno",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "scottmi02",
+    "fullName": "Mickey Scott",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Weimar",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "swandma01",
+    "fullName": "Marty Swandell",
+    "birthYear": 1841,
+    "birthDecade": 1840,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Baden",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "zuletju01",
+    "fullName": "Julio Zuleta",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": -0.2
+  },
+  {
+    "playerId": "bournra01",
+    "fullName": "Rafael Bournigal",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "campbhu01",
+    "fullName": "Hugh Campbell",
+    "birthYear": 1846,
+    "birthDecade": 1840,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "delosab01",
+    "fullName": "Abel De Los Santos",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "figuebi01",
+    "fullName": "Bien Figueroa",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "fleitan01",
+    "fullName": "Angel Fleitas",
+    "birthYear": 1914,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Los Abreus",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "jackssa01",
+    "fullName": "Sam Jackson",
+    "birthYear": 1849,
+    "birthDecade": 1840,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Ripon",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "mendoca01",
+    "fullName": "Carlos Mendoza",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "perezto03",
+    "fullName": "Tomas Perez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "richmsc01",
+    "fullName": "Scott Richmond",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "zimmejo01",
+    "fullName": "Jordan Zimmerman",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Kelowna",
+    "warCareer": -0.21
+  },
+  {
+    "playerId": "ascanjo01",
+    "fullName": "Jose Ascanio",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "delareu01",
+    "fullName": "Eury De La Rosa",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "diazed03",
+    "fullName": "Edwin Diaz",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "garcilu01",
+    "fullName": "Luis Garcia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "herrebo01",
+    "fullName": "Bobby Herrera",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Nuevo Laredo",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "kobayma01",
+    "fullName": "Masahide Kobayashi",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Otsuki",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "kriegku01",
+    "fullName": "Kurt Krieger",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Austria",
+    "birthCountryRaw": "Austria",
+    "birthCity": "Traisen",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "mosquju01",
+    "fullName": "Julio Mosquera",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "nunezjo01",
+    "fullName": "Jose Nunez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Jarabacoa",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "parrisa01",
+    "fullName": "Sam Parrilla",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "zabalad01",
+    "fullName": "Adrian Zabala",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "San Antonio de los Banos",
+    "warCareer": -0.22
+  },
+  {
+    "playerId": "martiro01",
+    "fullName": "Rogelio Martinez",
+    "birthYear": 1918,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Cidra",
+    "warCareer": -0.23
+  },
+  {
+    "playerId": "munizma01",
+    "fullName": "Manny Muniz",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": -0.23
+  },
+  {
+    "playerId": "muratto01",
+    "fullName": "Toru Murata",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Osaka",
+    "warCareer": -0.23
+  },
+  {
+    "playerId": "azocaos01",
+    "fullName": "Oscar Azocar",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Soro",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "beltrom01",
+    "fullName": "Omar Beltre",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "butleri01",
+    "fullName": "Rich Butler",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "campaal01",
+    "fullName": "Al Campanis",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Greece",
+    "birthCountryRaw": "Greece",
+    "birthCity": "Kos",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "chavean02",
+    "fullName": "Angel Chavez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "David",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "diazed01",
+    "fullName": "Edgar Diaz",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "felicje01",
+    "fullName": "Jesus Feliciano",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "hernaca02",
+    "fullName": "Carlos Hernandez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "hodgspa01",
+    "fullName": "Paul Hodgson",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "meloju01",
+    "fullName": "Juan Melo",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "pimenst01",
+    "fullName": "Stolmy Pimentel",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.24
+  },
+  {
+    "playerId": "canojo01",
+    "fullName": "Jose Cano",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Boca del Soco",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "caseybo01",
+    "fullName": "Bob Casey",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Adolphustown",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "collibi01",
+    "fullName": "Bill Collins",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Dublin",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "gardnal01",
+    "fullName": "Alex Gardner",
+    "birthYear": 1861,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "matosfr01",
+    "fullName": "Francisco Matos",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "mccabra01",
+    "fullName": "Ralph McCabe",
+    "birthYear": 1918,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Napanee",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "sandoda01",
+    "fullName": "Danny Sandoval",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "torregi01",
+    "fullName": "Gil Torres",
+    "birthYear": 1915,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Regla",
+    "warCareer": -0.25
+  },
+  {
+    "playerId": "encarlu01",
+    "fullName": "Luis Encarnacion",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "freiral01",
+    "fullName": "Alejandro Freire",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "gratebe01",
+    "fullName": "Beiker Graterol",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "jeltzst01",
+    "fullName": "Steve Jeltz",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": "Paris",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "mendeca01",
+    "fullName": "Carlos Mendez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "pacheal01",
+    "fullName": "Alex Pacheco",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "penabe01",
+    "fullName": "Bert Pena",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "perezto02",
+    "fullName": "Tony Perezchica",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexicali",
+    "warCareer": -0.26
+  },
+  {
+    "playerId": "cabreal03",
+    "fullName": "Alberto Cabrera",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": -0.27
+  },
+  {
+    "playerId": "capeljo01",
+    "fullName": "Jose Capellan",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": -0.27
+  },
+  {
+    "playerId": "mateoma01",
+    "fullName": "Marcos Mateo",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.27
+  },
+  {
+    "playerId": "mearsch01",
+    "fullName": "Chris Mears",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Ottawa",
+    "warCareer": -0.27
+  },
+  {
+    "playerId": "penara01",
+    "fullName": "Ramon Pena",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.27
+  },
+  {
+    "playerId": "sprined01",
+    "fullName": "Ed Springer",
+    "birthYear": 1867,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Oil Springs",
+    "warCareer": -0.27
+  },
+  {
+    "playerId": "biasaha01",
+    "fullName": "Hank Biasatti",
+    "birthYear": 1922,
+    "birthDecade": 1920,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "Beano",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "gladuro01",
+    "fullName": "Roland Gladu",
+    "birthYear": 1911,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "hernape01",
+    "fullName": "Pete Hernandez",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "javieal01",
+    "fullName": "Al Javier",
+    "birthYear": 1954,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "loewead01",
+    "fullName": "Adam Loewen",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Surrey",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "manzara01",
+    "fullName": "Ravelo Manzanillo",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "martios01",
+    "fullName": "Osvaldo Martinez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Carolina",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "melenfr01",
+    "fullName": "Francisco Melendez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "paredjo01",
+    "fullName": "Johnny Paredes",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "perdolu01",
+    "fullName": "Luis Perdomo",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "sanitam01",
+    "fullName": "Amauri Sanit",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.28
+  },
+  {
+    "playerId": "davidda01",
+    "fullName": "Dave Davidson",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Richmond Hill",
+    "warCareer": -0.29
+  },
+  {
+    "playerId": "fisheha01",
+    "fullName": "Harry Fisher",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Newbury",
+    "warCareer": -0.29
+  },
+  {
+    "playerId": "garcira03",
+    "fullName": "Ramon Garcia",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guanare",
+    "warCareer": -0.29
+  },
+  {
+    "playerId": "greenta01",
+    "fullName": "Taylor Green",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Comox",
+    "warCareer": -0.29
+  },
+  {
+    "playerId": "lobatjo01",
+    "fullName": "Jose Lobaton",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Acarigua",
+    "warCareer": -0.29
+  },
+  {
+    "playerId": "maldoca02",
+    "fullName": "Carlos Maldonado",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Chepo",
+    "warCareer": -0.29
+  },
+  {
+    "playerId": "alvarta01",
+    "fullName": "Tavo Alvarez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Obregon",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "clearjo01",
+    "fullName": "Joe Cleary",
+    "birthYear": 1918,
+    "birthDecade": 1910,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Cork",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "colevi01",
+    "fullName": "Victor Cole",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "Leningrad",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "colonro01",
+    "fullName": "Roman Colon",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "crompne01",
+    "fullName": "Ned Crompton",
+    "birthYear": 1889,
+    "birthDecade": 1880,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Liverpool",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "deagoro01",
+    "fullName": "Roger Deago",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Monagrillo",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "fernaos01",
+    "fullName": "Osvaldo Fernandez",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Holguin",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "handrve01",
+    "fullName": "Vern Handrahan",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Charlottetown",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "leonda01",
+    "fullName": "Danny Leon",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Concepcion",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "livinja01",
+    "fullName": "Jake Livingstone",
+    "birthYear": 1875,
+    "birthDecade": 1870,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "St. Petersburg",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "mateoju02",
+    "fullName": "Juan Mateo",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "mcilvir01",
+    "fullName": "Irish McIlveen",
+    "birthYear": 1880,
+    "birthDecade": 1880,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Belfast",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "roblese01",
+    "fullName": "Sergio Robles",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Magdalena de Kino",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "torrest01",
+    "fullName": "Steve Torrealba",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "valdewi01",
+    "fullName": "Wilson Valdez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nizao",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "valeryo01",
+    "fullName": "Yohanny Valera",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.3
+  },
+  {
+    "playerId": "cecenjo01",
+    "fullName": "Jose Cecena",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Obregon",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "daniepe01",
+    "fullName": "Pete Daniels",
+    "birthYear": 1864,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "duffyed01",
+    "fullName": "Ed Duffy",
+    "birthYear": 1844,
+    "birthDecade": 1840,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "hernaos01",
+    "fullName": "Oscar Hernandez",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Punto Fijo",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "machaan01",
+    "fullName": "Anderson Machado",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "nietoad01",
+    "fullName": "Adrian Nieto",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "prescbo01",
+    "fullName": "Bobby Prescott",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "romakja01",
+    "fullName": "Jamie Romak",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "sanchis01",
+    "fullName": "Israel Sanchez",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Falcon Lasvias",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "tovarwi01",
+    "fullName": "Wilfredo Tovar",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Santa Teresa",
+    "warCareer": -0.31
+  },
+  {
+    "playerId": "beltrfr01",
+    "fullName": "Francis Beltran",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "britobe01",
+    "fullName": "Bernardo Brito",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "gracefr01",
+    "fullName": "Frank Gracesqui",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "martian01",
+    "fullName": "Anastacio Martinez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "mckayco01",
+    "fullName": "Cody McKay",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "menento01",
+    "fullName": "Tony Menendez",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "ortizju01",
+    "fullName": "Junior Ortiz",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "ramirjo02",
+    "fullName": "Jose Ramirez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Yaguate",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "roonefr01",
+    "fullName": "Frank Rooney",
+    "birthYear": 1884,
+    "birthDecade": 1880,
+    "birthCountry": "Czech Republic",
+    "birthCountryRaw": "Czech Republic",
+    "birthCity": "Podebrady",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "sketcbu01",
+    "fullName": "Bud Sketchley",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Virden",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "valdeju01",
+    "fullName": "Julio Valdez",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "watkibi01",
+    "fullName": "Bill Watkins",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Brantford",
+    "warCareer": -0.32
+  },
+  {
+    "playerId": "cruzhe02",
+    "fullName": "Henry Cruz",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Christiansted",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "diazju02",
+    "fullName": "Juan Diaz",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "guerrde01",
+    "fullName": "Deolis Guerra",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Felix",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "ortizjo05",
+    "fullName": "Joe Ortiz",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "pfannbi01",
+    "fullName": "Bill Pfann",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "ramirma01",
+    "fullName": "Mario Ramirez",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Yauco",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "richtre01",
+    "fullName": "Reggie Richter",
+    "birthYear": 1888,
+    "birthDecade": 1880,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Dusseldorf",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "rohrle01",
+    "fullName": "Les Rohr",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Lowestoft",
+    "warCareer": -0.33
+  },
+  {
+    "playerId": "carream01",
+    "fullName": "Amalio Carreno",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Chacachacare",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "encaran01",
+    "fullName": "Angelo Encarnacion",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "friasca01",
+    "fullName": "Carlos Frias",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "guzmajo02",
+    "fullName": "Johnny Guzman",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hatillo Palma",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "huch01",
+    "fullName": "Chin-lung Hu",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Tainan City",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "jimenlu01",
+    "fullName": "Luis Jimenez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Bobare",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "reyesar01",
+    "fullName": "Argenis Reyes",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "smithkl01",
+    "fullName": "Klondike Smith",
+    "birthYear": 1887,
+    "birthDecade": 1880,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "London",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "valdejo01",
+    "fullName": "Jose Valdez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.34
+  },
+  {
+    "playerId": "alvarvi01",
+    "fullName": "Victor Alvarez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Culiacan",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "fujikky01",
+    "fullName": "Kyuji Fujikawa",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kochi",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "guerral01",
+    "fullName": "Alex Guerrero",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Las Tunas",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "hernafe01",
+    "fullName": "Fernando Hernandez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "ishiika01",
+    "fullName": "Kazuhisa Ishii",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Chiba",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "kidama01",
+    "fullName": "Masao Kida",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kokubunji",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "komiysa01",
+    "fullName": "Satoru Komiyama",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kashiwa",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "motajo01",
+    "fullName": "Jose Mota",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "pirieji01",
+    "fullName": "James Pirie",
+    "birthYear": 1853,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Dundas",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "quirira01",
+    "fullName": "Rafael Quirico",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "radmary01",
+    "fullName": "Ryan Radmanovich",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Calgary",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "sosahe01",
+    "fullName": "Henry Sosa",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": -0.35
+  },
+  {
+    "playerId": "britoti01",
+    "fullName": "Tilson Brito",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "camerja01",
+    "fullName": "Jack Cameron",
+    "birthYear": 1884,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Sydney",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "canizba01",
+    "fullName": "Barbaro Canizares",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "cockmji01",
+    "fullName": "Jim Cockman",
+    "birthYear": 1873,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Guelph",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "defrear01",
+    "fullName": "Arturo DeFreites",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "jimenlu02",
+    "fullName": "Luis Jimenez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "martida02",
+    "fullName": "David Martinez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "matafr01",
+    "fullName": "Frank Mata",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "miranwi01",
+    "fullName": "Willy Miranda",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Velasco",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "rodrifr01",
+    "fullName": "Freddy Rodriguez",
+    "birthYear": 1924,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "solisal01",
+    "fullName": "Ali Solis",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexicali",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "valdera01",
+    "fullName": "Rafael Valdez",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nizao",
+    "warCareer": -0.36
+  },
+  {
+    "playerId": "alcanis01",
+    "fullName": "Israel Alcantara",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "alvaror01",
+    "fullName": "Orlando Alvarez",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Grande",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "andujlu01",
+    "fullName": "Luis Andujar",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "choji01",
+    "fullName": "Jin Ho Cho",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Jun Ju City",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "ferrese01",
+    "fullName": "Sergio Ferrer",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "greenja01",
+    "fullName": "Jason Green",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Port Hope",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "liriape01",
+    "fullName": "Pedro Liriano",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "monteje01",
+    "fullName": "Jesus Montero",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guacara",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "olivehe01",
+    "fullName": "Hector Olivera",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "rosadlu01",
+    "fullName": "Luis Rosado",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "tateyyo01",
+    "fullName": "Yoshinori Tateyama",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Daito",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "weverst01",
+    "fullName": "Stefan Wever",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Marburg",
+    "warCareer": -0.37
+  },
+  {
+    "playerId": "devarce01",
+    "fullName": "Cesar Devarez",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Francisco de Macoris",
+    "warCareer": -0.38
+  },
+  {
+    "playerId": "diazed02",
+    "fullName": "Eddy Diaz",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -0.38
+  },
+  {
+    "playerId": "ettlema01",
+    "fullName": "Mark Ettles",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Perth",
+    "warCareer": -0.38
+  },
+  {
+    "playerId": "fukumka01",
+    "fullName": "Kazuo Fukumori",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kita Morokata-gun",
+    "warCareer": -0.38
+  },
+  {
+    "playerId": "posadle01",
+    "fullName": "Leo Posada",
+    "birthYear": 1936,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.38
+  },
+  {
+    "playerId": "vidaljo01",
+    "fullName": "Jose Vidal",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Batey Lechuga",
+    "warCareer": -0.38
+  },
+  {
+    "playerId": "bonilli01",
+    "fullName": "Lisalverto Bonilla",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Samana",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "burgoen01",
+    "fullName": "Enrique Burgos",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Chorrera",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "dorseje01",
+    "fullName": "Jerry Dorsey",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "frutoem01",
+    "fullName": "Emiliano Fruto",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "garciro01",
+    "fullName": "Rosman Garcia",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "hovlijo01",
+    "fullName": "Joe Hovlik",
+    "birthYear": 1884,
+    "birthDecade": 1880,
+    "birthCountry": "Austria",
+    "birthCountryRaw": "Austria",
+    "birthCity": null,
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "mejiami01",
+    "fullName": "Miguel Mejia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "nesbian01",
+    "fullName": "Angel Nesbitt",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "ortizba01",
+    "fullName": "Baby Ortiz",
+    "birthYear": 1919,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Camaguey",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "resslla01",
+    "fullName": "Larry Ressler",
+    "birthYear": 1848,
+    "birthDecade": 1840,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": null,
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "santoom01",
+    "fullName": "Omir Santos",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.39
+  },
+  {
+    "playerId": "cabreed01",
+    "fullName": "Edwar Cabrera",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.4
+  },
+  {
+    "playerId": "guevagi01",
+    "fullName": "Giomar Guevara",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": -0.4
+  },
+  {
+    "playerId": "hernaru02",
+    "fullName": "Rudy Hernandez",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Empalme",
+    "warCareer": -0.4
+  },
+  {
+    "playerId": "madriwa01",
+    "fullName": "Warner Madrigal",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.4
+  },
+  {
+    "playerId": "royje01",
+    "fullName": "Jean-Pierre Roy",
+    "birthYear": 1920,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.4
+  },
+  {
+    "playerId": "valdelu01",
+    "fullName": "Jairo Asencio",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana Grande de Palenque",
+    "warCareer": -0.4
+  },
+  {
+    "playerId": "almonhe01",
+    "fullName": "Hector Almonte",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "amarial01",
+    "fullName": "Alexi Amarista",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "diazma01",
+    "fullName": "Mario Diaz",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "hernace01",
+    "fullName": "Cesar Hernandez",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Yamasa",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "herreyo01",
+    "fullName": "Yoslan Herrera",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "maireos01",
+    "fullName": "Oswaldo Mairena",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Chinandega",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "mcgovar01",
+    "fullName": "Art McGovern",
+    "birthYear": 1882,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. John",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "ojedami01",
+    "fullName": "Miguel Ojeda",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Guaymas",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "rosarfr01",
+    "fullName": "Francisco Rosario",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Rafael del Yuma",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "ryancy01",
+    "fullName": "Cyclone Ryan",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Capperwhite",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "salasma02",
+    "fullName": "Marino Salas",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "valdeme01",
+    "fullName": "Merkin Valdez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.41
+  },
+  {
+    "playerId": "balazjo01",
+    "fullName": "John Balaz",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "cabrejo01",
+    "fullName": "Jose Cabrera",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Delgada",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "carabra01",
+    "fullName": "Ramon Caraballo",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Rio San Juan",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "diazar01",
+    "fullName": "Argenis Diaz",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guatire",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "escalni01",
+    "fullName": "Nino Escalera",
+    "birthYear": 1929,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "marreor01",
+    "fullName": "Oreste Marrero",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "mcfaror01",
+    "fullName": "Orlando McFarlane",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Oriente",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "mcmanpa01",
+    "fullName": "Pat McManus",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "nivarra01",
+    "fullName": "Ramon Nivar",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "porraed01",
+    "fullName": "Ed Porray",
+    "birthYear": 1888,
+    "birthDecade": 1880,
+    "birthCountry": "At Sea",
+    "birthCountryRaw": "At Sea",
+    "birthCity": null,
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "rederjo01",
+    "fullName": "Johnny Reder",
+    "birthYear": 1909,
+    "birthDecade": 1900,
+    "birthCountry": "Poland",
+    "birthCountryRaw": "Poland",
+    "birthCity": "Lublin",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "stephjo03",
+    "fullName": "John Stephens",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": -0.42
+  },
+  {
+    "playerId": "bautida01",
+    "fullName": "Danny Bautista",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "britoju01",
+    "fullName": "Juan Brito",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Moncion",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "castile01",
+    "fullName": "Lendy Castillo",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Santa Cruz",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "crosbke01",
+    "fullName": "Ken Crosby",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "New Denver",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "dominjo01",
+    "fullName": "Jose Dominguez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "garcion01",
+    "fullName": "Onelki Garcia",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guantanamo",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "hernaru01",
+    "fullName": "Rudy Hernandez",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "liriary01",
+    "fullName": "Rymer Liriano",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "pegueja01",
+    "fullName": "Jailen Peguero",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "plaskel01",
+    "fullName": "Elmo Plaskett",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": "Frederiksted",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "valdema02",
+    "fullName": "Mario Valdez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Obregon",
+    "warCareer": -0.43
+  },
+  {
+    "playerId": "abreuto01",
+    "fullName": "Tony Abreu",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "almonmi01",
+    "fullName": "Miguel Almonte",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "bergowi01",
+    "fullName": "William Bergolla",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "condera01",
+    "fullName": "Ramon Conde",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Juana Diaz",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "cyrer01",
+    "fullName": "Eric Cyr",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "durange01",
+    "fullName": "German Duran",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Zacatecas",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "friasha01",
+    "fullName": "Hanley Frias",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Altagracia",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "hallsch01",
+    "fullName": "Charlie Hallstrom",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Sweden",
+    "birthCountryRaw": "Sweden",
+    "birthCity": "Jonkoping",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "siffefr01",
+    "fullName": "Frank Siffell",
+    "birthYear": 1861,
+    "birthDecade": 1860,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "virgioz01",
+    "fullName": "Ozzie Virgil",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "walkeed01",
+    "fullName": "Ed Walker",
+    "birthYear": 1874,
+    "birthDecade": 1870,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Cambois",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "wangwe01",
+    "fullName": "Wei-Chung Wang",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Taiwan",
+    "birthCountryRaw": "Taiwan",
+    "birthCity": "Taitung City",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "wilsoni01",
+    "fullName": "Nigel Wilson",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Oshawa",
+    "warCareer": -0.44
+  },
+  {
+    "playerId": "crabbca01",
+    "fullName": "Callix Crabbe",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "U.S. Virgin Islands",
+    "birthCountryRaw": "V.I.",
+    "birthCity": null,
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "espinju01",
+    "fullName": "Juan Espino",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "gotayru01",
+    "fullName": "Ruben Gotay",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "hernama01",
+    "fullName": "Manny Hernandez",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "navarti01",
+    "fullName": "Tito Navarro",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "snydeco01",
+    "fullName": "Cooney Snyder",
+    "birthYear": 1873,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Chingacousy",
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "telisto01",
+    "fullName": "Tomas Telis",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "El Tigre",
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "tenerjo01",
+    "fullName": "John Tener",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.45
+  },
+  {
+    "playerId": "araujel01",
+    "fullName": "Elvis Araujo",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "cancero01",
+    "fullName": "Robinson Cancel",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Lajas",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "diazfe01",
+    "fullName": "Felix Diaz",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Las Matas de Farfan",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "igawake01",
+    "fullName": "Kei Igawa",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Higashi Ibaraki-gun",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "manniti01",
+    "fullName": "Tim Manning",
+    "birthYear": 1853,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Henley-on-Thames",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "ramsefe01",
+    "fullName": "Fernando Ramsey",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Rainbow City",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "rileyji02",
+    "fullName": "Jim Riley",
+    "birthYear": 1895,
+    "birthDecade": 1890,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Bayfield",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "romerra01",
+    "fullName": "Ramon Romero",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "rosser01",
+    "fullName": "Ernie Ross",
+    "birthYear": 1880,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "valdejo02",
+    "fullName": "Jordany Valdespin",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.46
+  },
+  {
+    "playerId": "edenmi01",
+    "fullName": "Mike Eden",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Fort Clayton",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "kentst01",
+    "fullName": "Steven Kent",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Frankfurt",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "marange01",
+    "fullName": "Georges Maranda",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Levis",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "meadch01",
+    "fullName": "Charlie Mead",
+    "birthYear": 1921,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vermilion",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "morilju01",
+    "fullName": "Juan Morillo",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "pondsi01",
+    "fullName": "Simon Pond",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "North Vancouver",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "rodrira01",
+    "fullName": "Rafael Rodriguez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "solanjh01",
+    "fullName": "Jhonatan Solano",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Barranquilla",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "vasques01",
+    "fullName": "Esmerling Vasquez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Tenares",
+    "warCareer": -0.47
+  },
+  {
+    "playerId": "alvarro01",
+    "fullName": "Rogelio Alvarez",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "bellast01",
+    "fullName": "Steve Bellan",
+    "birthYear": 1849,
+    "birthDecade": 1840,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "britojo01",
+    "fullName": "Jorge Brito",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Moncion",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "cabrefe01",
+    "fullName": "Fernando Cabrera",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Toa Baja",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "krichpa01",
+    "fullName": "Paul Krichell",
+    "birthYear": 1882,
+    "birthDecade": 1880,
+    "birthCountry": "France",
+    "birthCountryRaw": "France",
+    "birthCity": "Paris",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "lopezme01",
+    "fullName": "Mendy Lopez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Pimentel",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "prietal01",
+    "fullName": "Alex Prieto",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.48
+  },
+  {
+    "playerId": "burgoen02",
+    "fullName": "Enrique Burgos",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": -0.49
+  },
+  {
+    "playerId": "castrbe01",
+    "fullName": "Bernie Castro",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.49
+  },
+  {
+    "playerId": "guzmajo03",
+    "fullName": "Joel Guzman",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Quisqueya",
+    "warCareer": -0.49
+  },
+  {
+    "playerId": "pozoar01",
+    "fullName": "Arquimedez Pozo",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.49
+  },
+  {
+    "playerId": "roberda03",
+    "fullName": "Dave Roberts",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": -0.49
+  },
+  {
+    "playerId": "silveto01",
+    "fullName": "Tom Silverio",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.49
+  },
+  {
+    "playerId": "alvaros01",
+    "fullName": "Ossie Alvarez",
+    "birthYear": 1933,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Bolondron",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "chalmge01",
+    "fullName": "George Chalmers",
+    "birthYear": 1888,
+    "birthDecade": 1880,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Aberdeen",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "estraos01",
+    "fullName": "Oscar Estrada",
+    "birthYear": 1904,
+    "birthDecade": 1900,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "lauzege01",
+    "fullName": "George Lauzerique",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "lepinpe01",
+    "fullName": "Pete LePine",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "motaan01",
+    "fullName": "Andy Mota",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "perezsa01",
+    "fullName": "Santiago Perez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "rogered01",
+    "fullName": "Eddie Rogers",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.5
+  },
+  {
+    "playerId": "haywobi01",
+    "fullName": "Bill Haywood",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Colon",
+    "warCareer": -0.51
+  },
+  {
+    "playerId": "hugheto05",
+    "fullName": "Tom Hughes",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Ancon",
+    "warCareer": -0.51
+  },
+  {
+    "playerId": "matosos01",
+    "fullName": "Osiris Matos",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.51
+  },
+  {
+    "playerId": "sierrca01",
+    "fullName": "Candy Sierra",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.51
+  },
+  {
+    "playerId": "torreru01",
+    "fullName": "Rusty Torres",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aguadilla",
+    "warCareer": -0.51
+  },
+  {
+    "playerId": "collich01",
+    "fullName": "Chub Collins",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Dundas",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "cubilda01",
+    "fullName": "Darwin Cubillan",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Bobures",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "depauju01",
+    "fullName": "Julio DePaula",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "halmagr01",
+    "fullName": "Greg Halman",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Haarlem",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "lawro01",
+    "fullName": "Ron Law",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "morbajo01",
+    "fullName": "Jose Morban",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "sternad01",
+    "fullName": "Adam Stern",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": -0.52
+  },
+  {
+    "playerId": "centeju01",
+    "fullName": "Juan Centeno",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": -0.53
+  },
+  {
+    "playerId": "encarma01",
+    "fullName": "Mario Encarnacion",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -0.53
+  },
+  {
+    "playerId": "haadya01",
+    "fullName": "Yamid Haad",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -0.53
+  },
+  {
+    "playerId": "lugour01",
+    "fullName": "Urbano Lugo",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Punto Fijo",
+    "warCareer": -0.53
+  },
+  {
+    "playerId": "marqugo01",
+    "fullName": "Gonzalo Marquez",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Carupano",
+    "warCareer": -0.53
+  },
+  {
+    "playerId": "lezcaca01",
+    "fullName": "Carlos Lezcano",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": -0.54
+  },
+  {
+    "playerId": "marimsu01",
+    "fullName": "Sugar Ray Marimon",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -0.54
+  },
+  {
+    "playerId": "ottenjo01",
+    "fullName": "Joe Otten",
+    "birthYear": 1870,
+    "birthDecade": 1870,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": null,
+    "warCareer": -0.54
+  },
+  {
+    "playerId": "ryuja01",
+    "fullName": "Jae Kuk Ryu",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Choon Chung Do",
+    "warCareer": -0.54
+  },
+  {
+    "playerId": "valdejo03",
+    "fullName": "Jose Valdez",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Don Gregorio de Nizao",
+    "warCareer": -0.54
+  },
+  {
+    "playerId": "contrca01",
+    "fullName": "Carlos Contreras",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.55
+  },
+  {
+    "playerId": "lopezpe01",
+    "fullName": "Pedro Lopez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Moca",
+    "warCareer": -0.55
+  },
+  {
+    "playerId": "martija02",
+    "fullName": "Javier Martinez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -0.55
+  },
+  {
+    "playerId": "ortegan01",
+    "fullName": "Anthony Ortega",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ocumare del Tuy",
+    "warCareer": -0.55
+  },
+  {
+    "playerId": "soleral01",
+    "fullName": "Alay Soler",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": -0.55
+  },
+  {
+    "playerId": "breale01",
+    "fullName": "Leslie Brea",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.56
+  },
+  {
+    "playerId": "cardoja01",
+    "fullName": "Javier Cardona",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.56
+  },
+  {
+    "playerId": "gomezal01",
+    "fullName": "Alexis Gomez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Loma de Cabrera",
+    "warCareer": -0.56
+  },
+  {
+    "playerId": "millejo01",
+    "fullName": "Joe Miller",
+    "birthYear": 1850,
+    "birthDecade": 1850,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": -0.56
+  },
+  {
+    "playerId": "suthele01",
+    "fullName": "Leo Sutherland",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": -0.56
+  },
+  {
+    "playerId": "cheveto01",
+    "fullName": "Tony Chevez",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Telica",
+    "warCareer": -0.57
+  },
+  {
+    "playerId": "moyast01",
+    "fullName": "Steven Moya",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.57
+  },
+  {
+    "playerId": "aquingr01",
+    "fullName": "Greg Aquino",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Palenque",
+    "warCareer": -0.58
+  },
+  {
+    "playerId": "estraho01",
+    "fullName": "Horacio Estrada",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Joaquin",
+    "warCareer": -0.58
+  },
+  {
+    "playerId": "guzmado01",
+    "fullName": "Domingo Guzman",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.58
+  },
+  {
+    "playerId": "munozar01",
+    "fullName": "Arnie Munoz",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Mao",
+    "warCareer": -0.58
+  },
+  {
+    "playerId": "spoljpa01",
+    "fullName": "Paul Spoljaric",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Kelowna",
+    "warCareer": -0.58
+  },
+  {
+    "playerId": "younghe01",
+    "fullName": "Henry Youngman",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Horde",
+    "warCareer": -0.58
+  },
+  {
+    "playerId": "guerrju01",
+    "fullName": "Juan Guerrero",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Los Llanos",
+    "warCareer": -0.59
+  },
+  {
+    "playerId": "hawksbl01",
+    "fullName": "Blake Hawksworth",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "North Vancouver",
+    "warCareer": -0.59
+  },
+  {
+    "playerId": "lopezar01",
+    "fullName": "Art Lopez",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": -0.59
+  },
+  {
+    "playerId": "riosda01",
+    "fullName": "Danny Rios",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Spain",
+    "birthCountryRaw": "Spain",
+    "birthCity": "Madrid",
+    "warCareer": -0.59
+  },
+  {
+    "playerId": "seguife01",
+    "fullName": "Fernando Seguignol",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": null,
+    "warCareer": -0.59
+  },
+  {
+    "playerId": "uphamjo01",
+    "fullName": "John Upham",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Windsor",
+    "warCareer": -0.59
+  },
+  {
+    "playerId": "benitya01",
+    "fullName": "Yamil Benitez",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": -0.6
+  },
+  {
+    "playerId": "hermore01",
+    "fullName": "Remy Hermoso",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": null,
+    "warCareer": -0.6
+  },
+  {
+    "playerId": "nomurta01",
+    "fullName": "Takahito Nomura",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": null,
+    "warCareer": -0.6
+  },
+  {
+    "playerId": "nunezvl01",
+    "fullName": "Vladimir Nunez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.6
+  },
+  {
+    "playerId": "romeral01",
+    "fullName": "Alex Romero",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.6
+  },
+  {
+    "playerId": "sucreje01",
+    "fullName": "Jesus Sucre",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": -0.6
+  },
+  {
+    "playerId": "gabinar01",
+    "fullName": "Armando Gabino",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.61
+  },
+  {
+    "playerId": "henrios01",
+    "fullName": "Oscar Henriquez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": -0.61
+  },
+  {
+    "playerId": "malavjo01",
+    "fullName": "Jose Malave",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": -0.61
+  },
+  {
+    "playerId": "martilu01",
+    "fullName": "Luis Martinez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.61
+  },
+  {
+    "playerId": "yabutya01",
+    "fullName": "Yasuhiko Yabuta",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Kishiwada",
+    "warCareer": -0.61
+  },
+  {
+    "playerId": "almoned01",
+    "fullName": "Edwin Almonte",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "baezbe01",
+    "fullName": "Benito Baez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bonao",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "culmewi01",
+    "fullName": "Wil Culmer",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Bahamas",
+    "birthCountryRaw": "Bahamas",
+    "birthCity": "Nassau",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "lyonspa01",
+    "fullName": "Pat Lyons",
+    "birthYear": 1860,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Belleville",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "madurca01",
+    "fullName": "Calvin Maduro",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Aruba",
+    "birthCountryRaw": "Aruba",
+    "birthCity": "Santa Cruz",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "montera01",
+    "fullName": "Rafael Montero",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Higuerito",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "nunezfr01",
+    "fullName": "Franklin Nunez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "palmeem01",
+    "fullName": "Emilio Palmero",
+    "birthYear": 1895,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Guanabacoa",
+    "warCareer": -0.62
+  },
+  {
+    "playerId": "fenwibo01",
+    "fullName": "Bobby Fenwick",
+    "birthYear": 1946,
+    "birthDecade": 1940,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Naha",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "gutieju01",
+    "fullName": "J. C. Gutierrez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto La Cruz",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "padiljo01",
+    "fullName": "Jorge Padilla",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "reyesre01",
+    "fullName": "Rene Reyes",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Margarita",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "rodrili01",
+    "fullName": "Liu Rodriguez",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "sanchje01",
+    "fullName": "Jesus Sanchez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nizao",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "solanju01",
+    "fullName": "Julio Solano",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Agua Blanca",
+    "warCareer": -0.63
+  },
+  {
+    "playerId": "canseoz01",
+    "fullName": "Ozzie Canseco",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.64
+  },
+  {
+    "playerId": "garcich01",
+    "fullName": "Chico Garcia",
+    "birthYear": 1924,
+    "birthDecade": 1920,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Veracruz",
+    "warCareer": -0.64
+  },
+  {
+    "playerId": "guaipma01",
+    "fullName": "Mayckol Guaipe",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barcelona",
+    "warCareer": -0.64
+  },
+  {
+    "playerId": "swindrj01",
+    "fullName": "R. J. Swindle",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.64
+  },
+  {
+    "playerId": "deloslu02",
+    "fullName": "Luis de los Santos",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.65
+  },
+  {
+    "playerId": "romeren01",
+    "fullName": "Enny Romero",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.65
+  },
+  {
+    "playerId": "vanbroz01",
+    "fullName": "Ozzie Van Brabant",
+    "birthYear": 1926,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Kingsville",
+    "warCareer": -0.65
+  },
+  {
+    "playerId": "alcanar01",
+    "fullName": "Arismendy Alcantara",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.66
+  },
+  {
+    "playerId": "checoro01",
+    "fullName": "Robinson Checo",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.66
+  },
+  {
+    "playerId": "jorgear01",
+    "fullName": "Arndt Jorgens",
+    "birthYear": 1905,
+    "birthDecade": 1900,
+    "birthCountry": "Norway",
+    "birthCountryRaw": "Norway",
+    "birthCity": "Modum",
+    "warCareer": -0.66
+  },
+  {
+    "playerId": "laforpe01",
+    "fullName": "Pete LaForest",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hull",
+    "warCareer": -0.66
+  },
+  {
+    "playerId": "leonjo01",
+    "fullName": "Jose Leon",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Cayey",
+    "warCareer": -0.66
+  },
+  {
+    "playerId": "figueje01",
+    "fullName": "Jesus Figueroa",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.67
+  },
+  {
+    "playerId": "mastnto01",
+    "fullName": "Tom Mastny",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Indonesia",
+    "birthCountryRaw": "Indonesia",
+    "birthCity": "East Bontang",
+    "warCareer": -0.67
+  },
+  {
+    "playerId": "braunry01",
+    "fullName": "Ryan Braun",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Kitchener",
+    "warCareer": -0.68
+  },
+  {
+    "playerId": "molingu01",
+    "fullName": "Gustavo Molina",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": -0.68
+  },
+  {
+    "playerId": "herrejo02",
+    "fullName": "Jose Herrera",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.69
+  },
+  {
+    "playerId": "terrelu01",
+    "fullName": "Luis Terrero",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": -0.7
+  },
+  {
+    "playerId": "aumonph01",
+    "fullName": "Phillippe Aumont",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Gatineau",
+    "warCareer": -0.71
+  },
+  {
+    "playerId": "escobed02",
+    "fullName": "Edwin Escobar",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Sabana",
+    "warCareer": -0.71
+  },
+  {
+    "playerId": "garcire01",
+    "fullName": "Reynaldo Garcia",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Nagua",
+    "warCareer": -0.71
+  },
+  {
+    "playerId": "normane01",
+    "fullName": "Nelson Norman",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.71
+  },
+  {
+    "playerId": "obandsh01",
+    "fullName": "Sherman Obando",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": null,
+    "warCareer": -0.71
+  },
+  {
+    "playerId": "rodrihe03",
+    "fullName": "Henry Rodriguez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Santa Barbara",
+    "warCareer": -0.71
+  },
+  {
+    "playerId": "calixor01",
+    "fullName": "Orlando Calixte",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.72
+  },
+  {
+    "playerId": "rodrijo01",
+    "fullName": "Jose Rodriguez",
+    "birthYear": 1894,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.72
+  },
+  {
+    "playerId": "mazalu01",
+    "fullName": "Luis Maza",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Cumana",
+    "warCareer": -0.73
+  },
+  {
+    "playerId": "castrlu01",
+    "fullName": "Lou Castro",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Medellin",
+    "warCareer": -0.74
+  },
+  {
+    "playerId": "montefe01",
+    "fullName": "Felipe Montemayor",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monterrey",
+    "warCareer": -0.74
+  },
+  {
+    "playerId": "pollilo01",
+    "fullName": "Lou Polli",
+    "birthYear": 1901,
+    "birthDecade": 1900,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "Baveno",
+    "warCareer": -0.74
+  },
+  {
+    "playerId": "roblera01",
+    "fullName": "Rafael Robles",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.74
+  },
+  {
+    "playerId": "salazan01",
+    "fullName": "Angel Salazar",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Anaco",
+    "warCareer": -0.74
+  },
+  {
+    "playerId": "ynoara01",
+    "fullName": "Rafael Ynoa",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.74
+  },
+  {
+    "playerId": "aragoan01",
+    "fullName": "Angel Aragon",
+    "birthYear": 1890,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.75
+  },
+  {
+    "playerId": "castrda01",
+    "fullName": "Daniel Castro",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Guaymas",
+    "warCareer": -0.75
+  },
+  {
+    "playerId": "lawsoal01",
+    "fullName": "Al Lawson",
+    "birthYear": 1869,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "London",
+    "warCareer": -0.75
+  },
+  {
+    "playerId": "olivaed01",
+    "fullName": "Ed Olivares",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": -0.75
+  },
+  {
+    "playerId": "puentmi01",
+    "fullName": "Migel Puente",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Luis Potosi",
+    "warCareer": -0.75
+  },
+  {
+    "playerId": "santovi01",
+    "fullName": "Victor Santos",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.75
+  },
+  {
+    "playerId": "mckeeji01",
+    "fullName": "Jim McKeever",
+    "birthYear": 1861,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. John",
+    "warCareer": -0.76
+  },
+  {
+    "playerId": "nichosa01",
+    "fullName": "Sam Nicholl",
+    "birthYear": 1869,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -0.76
+  },
+  {
+    "playerId": "parrajo01",
+    "fullName": "Jose Parra",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Jacagua",
+    "warCareer": -0.76
+  },
+  {
+    "playerId": "sotone01",
+    "fullName": "Neftali Soto",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Manati",
+    "warCareer": -0.76
+  },
+  {
+    "playerId": "crucefr01",
+    "fullName": "Francisco Cruceta",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Rancho Viejo",
+    "warCareer": -0.77
+  },
+  {
+    "playerId": "kingsge01",
+    "fullName": "Gene Kingsale",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Aruba",
+    "birthCountryRaw": "Aruba",
+    "birthCity": "Solito",
+    "warCareer": -0.77
+  },
+  {
+    "playerId": "mooreje01",
+    "fullName": "Jerry Moore",
+    "birthYear": 1855,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Windsor",
+    "warCareer": -0.77
+  },
+  {
+    "playerId": "perezwi01",
+    "fullName": "Williams Perez",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Acarigua",
+    "warCareer": -0.77
+  },
+  {
+    "playerId": "pladsgo01",
+    "fullName": "Gordie Pladson",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "New Westminster",
+    "warCareer": -0.77
+  },
+  {
+    "playerId": "garibda01",
+    "fullName": "Daniel Garibay",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Maneadero",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "hernaad01",
+    "fullName": "Adrian Hernandez",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "lakeju01",
+    "fullName": "Junior Lake",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "landrla01",
+    "fullName": "Larry Landreth",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Stratford",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "mccurje01",
+    "fullName": "Jeff McCurry",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "ortizro01",
+    "fullName": "Roberto Ortiz",
+    "birthYear": 1915,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Camaguey",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "veraswi01",
+    "fullName": "Wilton Veras",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": -0.78
+  },
+  {
+    "playerId": "brazoyh01",
+    "fullName": "Yhency Brazoban",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.79
+  },
+  {
+    "playerId": "burgohi01",
+    "fullName": "Hiram Burgos",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Cayey",
+    "warCareer": -0.79
+  },
+  {
+    "playerId": "jimenge01",
+    "fullName": "German Jimenez",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Santiago Ixcuintla",
+    "warCareer": -0.79
+  },
+  {
+    "playerId": "sierrmo01",
+    "fullName": "Moises Sierra",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.8
+  },
+  {
+    "playerId": "velasgu01",
+    "fullName": "Guillermo Velasquez",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexicali",
+    "warCareer": -0.8
+  },
+  {
+    "playerId": "almonzo01",
+    "fullName": "Zoilo Almonte",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.81
+  },
+  {
+    "playerId": "garcimi02",
+    "fullName": "Miguel Garcia",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -0.81
+  },
+  {
+    "playerId": "nakamno01",
+    "fullName": "Norihiro Nakamura",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Osaka",
+    "warCareer": -0.81
+  },
+  {
+    "playerId": "penafr01",
+    "fullName": "Francisco Pena",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.81
+  },
+  {
+    "playerId": "tosonre01",
+    "fullName": "Rene Tosoni",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -0.81
+  },
+  {
+    "playerId": "walkege01",
+    "fullName": "George Walker",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Hamilton",
+    "warCareer": -0.81
+  },
+  {
+    "playerId": "mackeke01",
+    "fullName": "Ken MacKenzie",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Gore Bay",
+    "warCareer": -0.82
+  },
+  {
+    "playerId": "siddajo01",
+    "fullName": "Joe Siddall",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Windsor",
+    "warCareer": -0.82
+  },
+  {
+    "playerId": "abreuwi01",
+    "fullName": "Winston Abreu",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Cotui",
+    "warCareer": -0.83
+  },
+  {
+    "playerId": "britoso01",
+    "fullName": "Socrates Brito",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": -0.83
+  },
+  {
+    "playerId": "nichoal01",
+    "fullName": "Al Nichols",
+    "birthYear": 1852,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Worcester",
+    "warCareer": -0.83
+  },
+  {
+    "playerId": "olivajo01",
+    "fullName": "Jose Oliva",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.83
+  },
+  {
+    "playerId": "hurtaed01",
+    "fullName": "Edwin Hurtado",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -0.84
+  },
+  {
+    "playerId": "mathisc01",
+    "fullName": "Scott Mathieson",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.84
+  },
+  {
+    "playerId": "schesdu01",
+    "fullName": "Dutch Schesler",
+    "birthYear": 1900,
+    "birthDecade": 1900,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Frankfort",
+    "warCareer": -0.84
+  },
+  {
+    "playerId": "serrawa01",
+    "fullName": "Wascar Serrano",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.84
+  },
+  {
+    "playerId": "blancto01",
+    "fullName": "Tony Blanco",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Juan de la Maguana",
+    "warCareer": -0.86
+  },
+  {
+    "playerId": "deloslu01",
+    "fullName": "Luis de los Santos",
+    "birthYear": 1966,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Cristobal",
+    "warCareer": -0.86
+  },
+  {
+    "playerId": "gonzaal03",
+    "fullName": "Alberto Gonzalez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -0.86
+  },
+  {
+    "playerId": "nakammi01",
+    "fullName": "Micheal Nakamura",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Nara",
+    "warCareer": -0.87
+  },
+  {
+    "playerId": "oelkebr01",
+    "fullName": "Bryan Oelkers",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Spain",
+    "birthCountryRaw": "Spain",
+    "birthCity": "Zaragoza",
+    "warCareer": -0.87
+  },
+  {
+    "playerId": "penahi01",
+    "fullName": "Hipolito Pena",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Fantino",
+    "warCareer": -0.87
+  },
+  {
+    "playerId": "casanra01",
+    "fullName": "Raul Casanova",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": -0.88
+  },
+  {
+    "playerId": "ramirel01",
+    "fullName": "Elizardo Ramirez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": -0.88
+  },
+  {
+    "playerId": "rodrian01",
+    "fullName": "Aneury Rodriguez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Higuey",
+    "warCareer": -0.88
+  },
+  {
+    "playerId": "atilalu01",
+    "fullName": "Luis Atilano",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "bongju01",
+    "fullName": "Jung Bong",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "South Korea",
+    "birthCountryRaw": "South Korea",
+    "birthCity": "Seoul",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "cruzfa01",
+    "fullName": "Fausto Cruz",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Monte Cristi",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "mayayu01",
+    "fullName": "Yunesky Maya",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Pinar del Rio",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "oterori01",
+    "fullName": "Ricky Otero",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vega Baja",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "ramirro01",
+    "fullName": "Roberto Ramirez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Vega de Alatorre",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "silvajo01",
+    "fullName": "Jose Silva",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Tijuana",
+    "warCareer": -0.89
+  },
+  {
+    "playerId": "alexabo01",
+    "fullName": "Bob Alexander",
+    "birthYear": 1922,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "bullasi01",
+    "fullName": "Sim Bullas",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "calvoja01",
+    "fullName": "Jack Calvo",
+    "birthYear": 1894,
+    "birthDecade": 1890,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "castibr01",
+    "fullName": "Braulio Castillo",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Elias Pina",
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "mateohe01",
+    "fullName": "Henry Mateo",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "penato02",
+    "fullName": "Tony Pena",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "valdece01",
+    "fullName": "Cesar Valdez",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.9
+  },
+  {
+    "playerId": "gilje01",
+    "fullName": "Jerry Gil",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.91
+  },
+  {
+    "playerId": "laboyco01",
+    "fullName": "Coco Laboy",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": -0.91
+  },
+  {
+    "playerId": "fernajo01",
+    "fullName": "Jose Fernandez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Vega",
+    "warCareer": -0.92
+  },
+  {
+    "playerId": "hoganma01",
+    "fullName": "Marty Hogan",
+    "birthYear": 1869,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Wednesbury",
+    "warCareer": -0.92
+  },
+  {
+    "playerId": "riverca01",
+    "fullName": "Carlos Rivera",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Fajardo",
+    "warCareer": -0.92
+  },
+  {
+    "playerId": "thomptu01",
+    "fullName": "Tug Thompson",
+    "birthYear": 1856,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "London",
+    "warCareer": -0.92
+  },
+  {
+    "playerId": "gonzase01",
+    "fullName": "Severino Gonzalez",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Santiago",
+    "warCareer": -0.93
+  },
+  {
+    "playerId": "mullihe01",
+    "fullName": "Henry Mullin",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. John",
+    "warCareer": -0.93
+  },
+  {
+    "playerId": "nickemi01",
+    "fullName": "Mike Nickeas",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -0.93
+  },
+  {
+    "playerId": "banuema01",
+    "fullName": "Manny Banuelos",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Gomez Palacio",
+    "warCareer": -0.94
+  },
+  {
+    "playerId": "ponceca01",
+    "fullName": "Carlos Ponce",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -0.94
+  },
+  {
+    "playerId": "sanchor01",
+    "fullName": "Orlando Sanchez",
+    "birthYear": 1956,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Canovanas",
+    "warCareer": -0.94
+  },
+  {
+    "playerId": "telemam01",
+    "fullName": "Amaury Telemaco",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Higuey",
+    "warCareer": -0.94
+  },
+  {
+    "playerId": "triunca01",
+    "fullName": "Carlos Triunfel",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.94
+  },
+  {
+    "playerId": "ullrisa01",
+    "fullName": "Sandy Ullrich",
+    "birthYear": 1921,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.94
+  },
+  {
+    "playerId": "kuwatma01",
+    "fullName": "Masumi Kuwata",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Yao",
+    "warCareer": -0.95
+  },
+  {
+    "playerId": "lerouch01",
+    "fullName": "Chris Leroux",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -0.95
+  },
+  {
+    "playerId": "richada02",
+    "fullName": "Danny Richar",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -0.95
+  },
+  {
+    "playerId": "montere01",
+    "fullName": "Rene Monteagudo",
+    "birthYear": 1916,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -0.96
+  },
+  {
+    "playerId": "navarya01",
+    "fullName": "Yamaico Navarro",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.96
+  },
+  {
+    "playerId": "thormsc01",
+    "fullName": "Scott Thorman",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Cambridge",
+    "warCareer": -0.96
+  },
+  {
+    "playerId": "cuetobe01",
+    "fullName": "Bert Cueto",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "San Luis",
+    "warCareer": -0.97
+  },
+  {
+    "playerId": "delaceu01",
+    "fullName": "Frankie De La Cruz",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.97
+  },
+  {
+    "playerId": "monteau01",
+    "fullName": "Aurelio Monteagudo",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Caibarien",
+    "warCareer": -0.97
+  },
+  {
+    "playerId": "rondojo01",
+    "fullName": "Jorge Rondon",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Calabozo",
+    "warCareer": -0.97
+  },
+  {
+    "playerId": "doylejo02",
+    "fullName": "John Doyle",
+    "birthYear": 1858,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Halifax",
+    "warCareer": -0.98
+  },
+  {
+    "playerId": "johnsab02",
+    "fullName": "Abbie Johnson",
+    "birthYear": 1871,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Portland",
+    "warCareer": -0.98
+  },
+  {
+    "playerId": "rodrine01",
+    "fullName": "Nerio Rodriguez",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -0.98
+  },
+  {
+    "playerId": "silvawa01",
+    "fullName": "Walter Silva",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mazatlan",
+    "warCareer": -0.98
+  },
+  {
+    "playerId": "wiggsji01",
+    "fullName": "Jimmy Wiggs",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Norway",
+    "birthCountryRaw": "Norway",
+    "birthCity": "Trondhjem",
+    "warCareer": -0.98
+  },
+  {
+    "playerId": "almoner01",
+    "fullName": "Erick Almonte",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -0.99
+  },
+  {
+    "playerId": "craigpe01",
+    "fullName": "Pete Craig",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "LaSalle",
+    "warCareer": -0.99
+  },
+  {
+    "playerId": "ochoaiv01",
+    "fullName": "Ivan Ochoa",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guacara",
+    "warCareer": -0.99
+  },
+  {
+    "playerId": "osorifr01",
+    "fullName": "Franquelis Osoria",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -0.99
+  },
+  {
+    "playerId": "clackbo01",
+    "fullName": "Bobby Clack",
+    "birthYear": 1850,
+    "birthDecade": 1850,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": -1
+  },
+  {
+    "playerId": "llenawi01",
+    "fullName": "Winston Llenas",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -1
+  },
+  {
+    "playerId": "martean01",
+    "fullName": "Andy Marte",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Tapia",
+    "warCareer": -1
+  },
+  {
+    "playerId": "martima01",
+    "fullName": "Marty Martinez",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -1
+  },
+  {
+    "playerId": "penajo01",
+    "fullName": "Jose Pena",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Juarez",
+    "warCareer": -1
+  },
+  {
+    "playerId": "riosju01",
+    "fullName": "Juan Rios",
+    "birthYear": 1942,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": -1
+  },
+  {
+    "playerId": "bautide01",
+    "fullName": "Denny Bautista",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sanchez",
+    "warCareer": -1.01
+  },
+  {
+    "playerId": "blancos01",
+    "fullName": "Ossie Blanco",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -1.01
+  },
+  {
+    "playerId": "hernaal01",
+    "fullName": "Alex Hernandez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": -1.01
+  },
+  {
+    "playerId": "marteal01",
+    "fullName": "Alfredo Marte",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.01
+  },
+  {
+    "playerId": "paulife01",
+    "fullName": "Felipe Paulino",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.01
+  },
+  {
+    "playerId": "beatope01",
+    "fullName": "Pedro Beato",
+    "birthYear": 1986,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.02
+  },
+  {
+    "playerId": "bernhju01",
+    "fullName": "Juan Bernhardt",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.02
+  },
+  {
+    "playerId": "jimenma01",
+    "fullName": "Manny Jimenez",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.02
+  },
+  {
+    "playerId": "randane01",
+    "fullName": "Newt Randall",
+    "birthYear": 1880,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "New Lowell",
+    "warCareer": -1.02
+  },
+  {
+    "playerId": "sanchal01",
+    "fullName": "Alejandro Sanchez",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.02
+  },
+  {
+    "playerId": "garcipe01",
+    "fullName": "Pedro Garcia",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guayama",
+    "warCareer": -1.03
+  },
+  {
+    "playerId": "infanal01",
+    "fullName": "Alexis Infante",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -1.05
+  },
+  {
+    "playerId": "otanewi01",
+    "fullName": "Willis Otanez",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Vega Baja",
+    "warCareer": -1.05
+  },
+  {
+    "playerId": "solisma01",
+    "fullName": "Marcelino Solis",
+    "birthYear": 1930,
+    "birthDecade": 1930,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Real de Catorce",
+    "warCareer": -1.05
+  },
+  {
+    "playerId": "wagnehe02",
+    "fullName": "Hector Wagner",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Juan de la Maguana",
+    "warCareer": -1.05
+  },
+  {
+    "playerId": "woodfr01",
+    "fullName": "Fred Wood",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Dundas",
+    "warCareer": -1.05
+  },
+  {
+    "playerId": "cletoma01",
+    "fullName": "Maikel Cleto",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.06
+  },
+  {
+    "playerId": "thomabr01",
+    "fullName": "Brad Thomas",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": -1.06
+  },
+  {
+    "playerId": "frobedo01",
+    "fullName": "Doug Frobel",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Ottawa",
+    "warCareer": -1.07
+  },
+  {
+    "playerId": "perazos01",
+    "fullName": "Oswaldo Peraza",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": -1.07
+  },
+  {
+    "playerId": "rodriro01",
+    "fullName": "Roberto Rodriguez",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -1.07
+  },
+  {
+    "playerId": "faneyri01",
+    "fullName": "Rikkert Faneyte",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Amsterdam",
+    "warCareer": -1.09
+  },
+  {
+    "playerId": "hernape02",
+    "fullName": "Pedro Hernandez",
+    "birthYear": 1989,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -1.09
+  },
+  {
+    "playerId": "leshebr01",
+    "fullName": "Brian Lesher",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Belgium",
+    "birthCountryRaw": "Belgium",
+    "birthCity": "Wilrijk",
+    "warCareer": -1.09
+  },
+  {
+    "playerId": "macarma01",
+    "fullName": "Mac MacArthur",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": "Glasgow",
+    "warCareer": -1.09
+  },
+  {
+    "playerId": "vargaro01",
+    "fullName": "Roberto Vargas",
+    "birthYear": 1929,
+    "birthDecade": 1920,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -1.09
+  },
+  {
+    "playerId": "whitemi01",
+    "fullName": "Milt Whitehead",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -1.09
+  },
+  {
+    "playerId": "adamecr01",
+    "fullName": "Cristhian Adames",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.1
+  },
+  {
+    "playerId": "huberju01",
+    "fullName": "Justin Huber",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Melbourne",
+    "warCareer": -1.1
+  },
+  {
+    "playerId": "ramiral02",
+    "fullName": "Alex Ramirez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -1.1
+  },
+  {
+    "playerId": "katolja01",
+    "fullName": "Jack Katoll",
+    "birthYear": 1872,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": null,
+    "warCareer": -1.11
+  },
+  {
+    "playerId": "martife02",
+    "fullName": "Fernando Martinez",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Rio San Juan",
+    "warCareer": -1.11
+  },
+  {
+    "playerId": "buelofr01",
+    "fullName": "Fritz Buelow",
+    "birthYear": 1876,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Berlin",
+    "warCareer": -1.12
+  },
+  {
+    "playerId": "crespce01",
+    "fullName": "Cesar Crespo",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -1.12
+  },
+  {
+    "playerId": "vegaje01",
+    "fullName": "Jesus Vega",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -1.12
+  },
+  {
+    "playerId": "hernadi01",
+    "fullName": "Diory Hernandez",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.13
+  },
+  {
+    "playerId": "delroen01",
+    "fullName": "Enerio Del Rosario",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santa Lucia",
+    "warCareer": -1.15
+  },
+  {
+    "playerId": "ortizlu01",
+    "fullName": "Luis Ortiz",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.15
+  },
+  {
+    "playerId": "alcalsa01",
+    "fullName": "Santo Alcala",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.16
+  },
+  {
+    "playerId": "bazaryo01",
+    "fullName": "Yorman Bazardo",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -1.16
+  },
+  {
+    "playerId": "daviara01",
+    "fullName": "Ray Daviault",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -1.16
+  },
+  {
+    "playerId": "taveros01",
+    "fullName": "Oscar Taveras",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -1.16
+  },
+  {
+    "playerId": "aybarma01",
+    "fullName": "Manny Aybar",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bani",
+    "warCareer": -1.17
+  },
+  {
+    "playerId": "doubrfe01",
+    "fullName": "Felix Doubront",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": -1.17
+  },
+  {
+    "playerId": "jimenke01",
+    "fullName": "Kelvin Jimenez",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sanchez",
+    "warCareer": -1.17
+  },
+  {
+    "playerId": "fajarhe01",
+    "fullName": "Hector Fajardo",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Sahuayo",
+    "warCareer": -1.18
+  },
+  {
+    "playerId": "gonzade01",
+    "fullName": "Denny Gonzalez",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Sabana Grande de Boya",
+    "warCareer": -1.18
+  },
+  {
+    "playerId": "klassda01",
+    "fullName": "Danny Klassen",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Leamington",
+    "warCareer": -1.18
+  },
+  {
+    "playerId": "penawi01",
+    "fullName": "Wily Mo Pena",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Laguna Salada",
+    "warCareer": -1.18
+  },
+  {
+    "playerId": "dugasgu01",
+    "fullName": "Gus Dugas",
+    "birthYear": 1907,
+    "birthDecade": 1900,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. Jean de Matha",
+    "warCareer": -1.19
+  },
+  {
+    "playerId": "ramirmi01",
+    "fullName": "Milt Ramirez",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": -1.19
+  },
+  {
+    "playerId": "shiplcr01",
+    "fullName": "Craig Shipley",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Parramatta",
+    "warCareer": -1.19
+  },
+  {
+    "playerId": "medinra01",
+    "fullName": "Rafael Medina",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Panama",
+    "birthCountryRaw": "Panama",
+    "birthCity": "Panama",
+    "warCareer": -1.2
+  },
+  {
+    "playerId": "ramiror01",
+    "fullName": "Orlando Ramirez",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -1.2
+  },
+  {
+    "playerId": "bertore01",
+    "fullName": "Reno Bertoia",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "San Vito al Tagliamento",
+    "warCareer": -1.21
+  },
+  {
+    "playerId": "castepe01",
+    "fullName": "Pedro Castellano",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -1.21
+  },
+  {
+    "playerId": "lucidco01",
+    "fullName": "Con Lucid",
+    "birthYear": 1874,
+    "birthDecade": 1870,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Dublin",
+    "warCareer": -1.22
+  },
+  {
+    "playerId": "machadi01",
+    "fullName": "Dixon Machado",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "San Cristobal",
+    "warCareer": -1.22
+  },
+  {
+    "playerId": "mendolu01",
+    "fullName": "Luis Mendoza",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Veracruz",
+    "warCareer": -1.22
+  },
+  {
+    "playerId": "brownjo01",
+    "fullName": "Joe Brown",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": -1.23
+  },
+  {
+    "playerId": "mageebi01",
+    "fullName": "Bill Magee",
+    "birthYear": 1875,
+    "birthDecade": 1870,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": -1.23
+  },
+  {
+    "playerId": "castica01",
+    "fullName": "Carmelo Castillo",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.25
+  },
+  {
+    "playerId": "castiju01",
+    "fullName": "Juan Castillo",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.25
+  },
+  {
+    "playerId": "munozpe01",
+    "fullName": "Pedro Munoz",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": -1.26
+  },
+  {
+    "playerId": "gilgu01",
+    "fullName": "Gus Gil",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -1.27
+  },
+  {
+    "playerId": "gonzaed01",
+    "fullName": "Edgar Gonzalez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "San Nicolas de los Garza",
+    "warCareer": -1.27
+  },
+  {
+    "playerId": "martimi02",
+    "fullName": "Michael Martinez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.27
+  },
+  {
+    "playerId": "melenlu01",
+    "fullName": "Luis Melendez",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Aibonito",
+    "warCareer": -1.27
+  },
+  {
+    "playerId": "penaro01",
+    "fullName": "Roberto Pena",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.27
+  },
+  {
+    "playerId": "jimenho01",
+    "fullName": "Houston Jimenez",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mexico",
+    "warCareer": -1.28
+  },
+  {
+    "playerId": "mercelu01",
+    "fullName": "Luis Mercedes",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.28
+  },
+  {
+    "playerId": "montalu01",
+    "fullName": "Luis Montanez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -1.28
+  },
+  {
+    "playerId": "alberjo01",
+    "fullName": "Jose Alberro",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": -1.29
+  },
+  {
+    "playerId": "fordge01",
+    "fullName": "Gene Ford",
+    "birthYear": 1881,
+    "birthDecade": 1880,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Milton",
+    "warCareer": -1.29
+  },
+  {
+    "playerId": "valdesa01",
+    "fullName": "Sandy Valdespino",
+    "birthYear": 1939,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "San Jose de las Lajas",
+    "warCareer": -1.29
+  },
+  {
+    "playerId": "paredji01",
+    "fullName": "Jimmy Paredes",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": -1.3
+  },
+  {
+    "playerId": "astacez01",
+    "fullName": "Ezequiel Astacio",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": -1.31
+  },
+  {
+    "playerId": "hernago01",
+    "fullName": "Gorkys Hernandez",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guiria",
+    "warCareer": -1.31
+  },
+  {
+    "playerId": "nunezab02",
+    "fullName": "Abraham Nunez",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Bajos de Haina",
+    "warCareer": -1.32
+  },
+  {
+    "playerId": "sardilu01",
+    "fullName": "Luis Sardinas",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Upata",
+    "warCareer": -1.32
+  },
+  {
+    "playerId": "gonzaju02",
+    "fullName": "Julio Gonzalez",
+    "birthYear": 1952,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": -1.35
+  },
+  {
+    "playerId": "hernaje01",
+    "fullName": "Jesus Hernaiz",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -1.35
+  },
+  {
+    "playerId": "tatisra01",
+    "fullName": "Ramon Tatis",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Guayubin",
+    "warCareer": -1.35
+  },
+  {
+    "playerId": "garcifr01",
+    "fullName": "Freddy Garcia",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -1.36
+  },
+  {
+    "playerId": "hernale01",
+    "fullName": "Leo Hernandez",
+    "birthYear": 1959,
+    "birthDecade": 1950,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Santa Lucia",
+    "warCareer": -1.36
+  },
+  {
+    "playerId": "gardimi01",
+    "fullName": "Mike Gardiner",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Sarnia",
+    "warCareer": -1.37
+  },
+  {
+    "playerId": "vanderi01",
+    "fullName": "Rick van den Hurk",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Netherlands",
+    "birthCountryRaw": "Netherlands",
+    "birthCity": "Eindhoven",
+    "warCareer": -1.38
+  },
+  {
+    "playerId": "cedendo01",
+    "fullName": "Domingo Cedeno",
+    "birthYear": 1968,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -1.39
+  },
+  {
+    "playerId": "figaral01",
+    "fullName": "Alfredo Figaro",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Samana",
+    "warCareer": -1.39
+  },
+  {
+    "playerId": "igarary01",
+    "fullName": "Ryota Igarashi",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Tokyo",
+    "warCareer": -1.39
+  },
+  {
+    "playerId": "riverya01",
+    "fullName": "Yadiel Rivera",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Caguas",
+    "warCareer": -1.39
+  },
+  {
+    "playerId": "sanchan02",
+    "fullName": "Angel Sanchez",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": -1.39
+  },
+  {
+    "playerId": "roquejo01",
+    "fullName": "Jorge Roque",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Ponce",
+    "warCareer": -1.41
+  },
+  {
+    "playerId": "mendedo01",
+    "fullName": "Donaldo Mendez",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barquisimeto",
+    "warCareer": -1.42
+  },
+  {
+    "playerId": "alvarga01",
+    "fullName": "Gabe Alvarez",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Navojoa",
+    "warCareer": -1.43
+  },
+  {
+    "playerId": "ozunapa01",
+    "fullName": "Pablo Ozuna",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.45
+  },
+  {
+    "playerId": "woodpe01",
+    "fullName": "Pete Wood",
+    "birthYear": 1867,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Dundas",
+    "warCareer": -1.45
+  },
+  {
+    "playerId": "jenniro01",
+    "fullName": "Robin Jennings",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Singapore",
+    "birthCountryRaw": "Singapore",
+    "birthCity": "Singapore",
+    "warCareer": -1.46
+  },
+  {
+    "playerId": "eiteled01",
+    "fullName": "Ed Eiteljorge",
+    "birthYear": 1871,
+    "birthDecade": 1870,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Berlin",
+    "warCareer": -1.48
+  },
+  {
+    "playerId": "delisju01",
+    "fullName": "Juan Delis",
+    "birthYear": 1928,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": -1.49
+  },
+  {
+    "playerId": "rivaslu01",
+    "fullName": "Luis Rivas",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": -1.49
+  },
+  {
+    "playerId": "rondobr01",
+    "fullName": "Bruce Rondon",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": -1.49
+  },
+  {
+    "playerId": "bennesh01",
+    "fullName": "Shayne Bennett",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Adelaide",
+    "warCareer": -1.5
+  },
+  {
+    "playerId": "martevi01",
+    "fullName": "Victor Marte",
+    "birthYear": 1980,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -1.52
+  },
+  {
+    "playerId": "polidgu01",
+    "fullName": "Gus Polidor",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Caracas",
+    "warCareer": -1.54
+  },
+  {
+    "playerId": "velezeu01",
+    "fullName": "Eugenio Velez",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -1.55
+  },
+  {
+    "playerId": "quinore01",
+    "fullName": "Rey Quinones",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -1.56
+  },
+  {
+    "playerId": "cedenro02",
+    "fullName": "Ronny Cedeno",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Puerto Cabello",
+    "warCareer": -1.57
+  },
+  {
+    "playerId": "cruzen01",
+    "fullName": "Enrique Cruz",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -1.57
+  },
+  {
+    "playerId": "carrima01",
+    "fullName": "Matias Carrillo",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": -1.58
+  },
+  {
+    "playerId": "durritr01",
+    "fullName": "Trent Durrington",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Australia",
+    "birthCountryRaw": "Australia",
+    "birthCity": "Sydney",
+    "warCareer": -1.58
+  },
+  {
+    "playerId": "florera02",
+    "fullName": "Ramon Flores",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Barinas",
+    "warCareer": -1.58
+  },
+  {
+    "playerId": "nievejo01",
+    "fullName": "Jose Nieves",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Guacara",
+    "warCareer": -1.59
+  },
+  {
+    "playerId": "segurjo01",
+    "fullName": "Jose Segura",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Fundacion",
+    "warCareer": -1.59
+  },
+  {
+    "playerId": "dejesiv02",
+    "fullName": "Ivan De Jesus",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Guaynabo",
+    "warCareer": -1.61
+  },
+  {
+    "playerId": "cuthbch01",
+    "fullName": "Cheslor Cuthbert",
+    "birthYear": 1992,
+    "birthDecade": 1990,
+    "birthCountry": "Nicaragua",
+    "birthCountryRaw": "Nicaragua",
+    "birthCity": "Corn Island",
+    "warCareer": -1.63
+  },
+  {
+    "playerId": "piefe01",
+    "fullName": "Felix Pie",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -1.63
+  },
+  {
+    "playerId": "rienzan01",
+    "fullName": "Andre Rienzo",
+    "birthYear": 1988,
+    "birthDecade": 1980,
+    "birthCountry": "Brazil",
+    "birthCountryRaw": "Brazil",
+    "birthCity": "Sao Paulo",
+    "warCareer": -1.63
+  },
+  {
+    "playerId": "curryto01",
+    "fullName": "Tony Curry",
+    "birthYear": 1937,
+    "birthDecade": 1930,
+    "birthCountry": "Bahamas",
+    "birthCountryRaw": "Bahamas",
+    "birthCity": "Nassau",
+    "warCareer": -1.64
+  },
+  {
+    "playerId": "felizmi01",
+    "fullName": "Michael Feliz",
+    "birthYear": 1993,
+    "birthDecade": 1990,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": -1.64
+  },
+  {
+    "playerId": "wainhda01",
+    "fullName": "Dave Wainhouse",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Toronto",
+    "warCareer": -1.64
+  },
+  {
+    "playerId": "olmedra01",
+    "fullName": "Ray Olmedo",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracay",
+    "warCareer": -1.65
+  },
+  {
+    "playerId": "alcarlu01",
+    "fullName": "Luis Alcaraz",
+    "birthYear": 1941,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": -1.66
+  },
+  {
+    "playerId": "clemeed02",
+    "fullName": "Edgard Clemente",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -1.66
+  },
+  {
+    "playerId": "romanjo02",
+    "fullName": "Jose Roman",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Puerto Plata",
+    "warCareer": -1.66
+  },
+  {
+    "playerId": "meulehe01",
+    "fullName": "Hensley Meulens",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Curacao",
+    "birthCountryRaw": "Curacao",
+    "birthCity": "Willemstad",
+    "warCareer": -1.67
+  },
+  {
+    "playerId": "paulaca01",
+    "fullName": "Carlos Paula",
+    "birthYear": 1927,
+    "birthDecade": 1920,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -1.68
+  },
+  {
+    "playerId": "gonzaan01",
+    "fullName": "Andy Gonzalez",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Rio Piedras",
+    "warCareer": -1.69
+  },
+  {
+    "playerId": "arciaos01",
+    "fullName": "Oswaldo Arcia",
+    "birthYear": 1991,
+    "birthDecade": 1990,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Anaco",
+    "warCareer": -1.72
+  },
+  {
+    "playerId": "ledezwi01",
+    "fullName": "Wil Ledezma",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valle de la Pascua",
+    "warCareer": -1.75
+  },
+  {
+    "playerId": "lizra01",
+    "fullName": "Radhames Liz",
+    "birthYear": 1983,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "El Seibo",
+    "warCareer": -1.75
+  },
+  {
+    "playerId": "pardoal01",
+    "fullName": "Al Pardo",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Spain",
+    "birthCountryRaw": "Spain",
+    "birthCity": "Oviedo",
+    "warCareer": -1.76
+  },
+  {
+    "playerId": "guerrwi01",
+    "fullName": "Wilton Guerrero",
+    "birthYear": 1974,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Don Gregorio",
+    "warCareer": -1.81
+  },
+  {
+    "playerId": "ramosdo01",
+    "fullName": "Domingo Ramos",
+    "birthYear": 1958,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago",
+    "warCareer": -1.83
+  },
+  {
+    "playerId": "gutiece01",
+    "fullName": "Cesar Gutierrez",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Coro",
+    "warCareer": -1.85
+  },
+  {
+    "playerId": "quirogu01",
+    "fullName": "Guillermo Quiroz",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -1.87
+  },
+  {
+    "playerId": "destror01",
+    "fullName": "Orestes Destrade",
+    "birthYear": 1962,
+    "birthDecade": 1960,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santiago de Cuba",
+    "warCareer": -1.9
+  },
+  {
+    "playerId": "martito01",
+    "fullName": "Tony Martinez",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Perico",
+    "warCareer": -1.92
+  },
+  {
+    "playerId": "belloro01",
+    "fullName": "Rob Belloir",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Heidelberg",
+    "warCareer": -1.93
+  },
+  {
+    "playerId": "noesihe01",
+    "fullName": "Hector Noesi",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Esperanza",
+    "warCareer": -1.93
+  },
+  {
+    "playerId": "mclaufr01",
+    "fullName": "Frank McLaughlin",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -1.98
+  },
+  {
+    "playerId": "mejiaro02",
+    "fullName": "Roberto Mejia",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Hato Mayor del Rey",
+    "warCareer": -1.98
+  },
+  {
+    "playerId": "moralje01",
+    "fullName": "Jerry Morales",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Yabucoa",
+    "warCareer": -1.99
+  },
+  {
+    "playerId": "martisa01",
+    "fullName": "Sandy Martinez",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Villa Mella",
+    "warCareer": -2
+  },
+  {
+    "playerId": "halpiji01",
+    "fullName": "Jim Halpin",
+    "birthYear": 1863,
+    "birthDecade": 1860,
+    "birthCountry": "United Kingdom",
+    "birthCountryRaw": "United Kingdom",
+    "birthCity": null,
+    "warCareer": -2.02
+  },
+  {
+    "playerId": "paganda01",
+    "fullName": "Dave Pagan",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Nipawin",
+    "warCareer": -2.03
+  },
+  {
+    "playerId": "johnsmi02",
+    "fullName": "Mike Johnson",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Edmonton",
+    "warCareer": -2.09
+  },
+  {
+    "playerId": "beltres01",
+    "fullName": "Esteban Beltre",
+    "birthYear": 1967,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Quisqueya",
+    "warCareer": -2.12
+  },
+  {
+    "playerId": "noboaju01",
+    "fullName": "Junior Noboa",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Azua",
+    "warCareer": -2.12
+  },
+  {
+    "playerId": "hoopebo01",
+    "fullName": "Bob Hooper",
+    "birthYear": 1922,
+    "birthDecade": 1920,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Leamington",
+    "warCareer": -2.14
+  },
+  {
+    "playerId": "guzmaed01",
+    "fullName": "Edwards Guzman",
+    "birthYear": 1976,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Bayamon",
+    "warCareer": -2.15
+  },
+  {
+    "playerId": "nievewi01",
+    "fullName": "Wil Nieves",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": -2.19
+  },
+  {
+    "playerId": "cintral01",
+    "fullName": "Alex Cintron",
+    "birthYear": 1978,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Humacao",
+    "warCareer": -2.21
+  },
+  {
+    "playerId": "hinesmi01",
+    "fullName": "Mike Hines",
+    "birthYear": 1862,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -2.24
+  },
+  {
+    "playerId": "castima01",
+    "fullName": "Manny Castillo",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -2.29
+  },
+  {
+    "playerId": "dalyto02",
+    "fullName": "Tom Daly",
+    "birthYear": 1891,
+    "birthDecade": 1890,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "St. John",
+    "warCareer": -2.29
+  },
+  {
+    "playerId": "cusicto01",
+    "fullName": "Andy Cusick",
+    "birthYear": 1857,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Limerick",
+    "warCareer": -2.3
+  },
+  {
+    "playerId": "nishits01",
+    "fullName": "Tsuyoshi Nishioka",
+    "birthYear": 1984,
+    "birthDecade": 1980,
+    "birthCountry": "Japan",
+    "birthCountryRaw": "Japan",
+    "birthCity": "Nara",
+    "warCareer": -2.3
+  },
+  {
+    "playerId": "samueam01",
+    "fullName": "Amado Samuel",
+    "birthYear": 1938,
+    "birthDecade": 1930,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -2.3
+  },
+  {
+    "playerId": "calvepa01",
+    "fullName": "Paul Calvert",
+    "birthYear": 1917,
+    "birthDecade": 1910,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Montreal",
+    "warCareer": -2.32
+  },
+  {
+    "playerId": "nieveme01",
+    "fullName": "Melvin Nieves",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "San Juan",
+    "warCareer": -2.32
+  },
+  {
+    "playerId": "betanyu01",
+    "fullName": "Yuniesky Betancourt",
+    "birthYear": 1982,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Santa Clara",
+    "warCareer": -2.34
+  },
+  {
+    "playerId": "martica02",
+    "fullName": "Carlos Martinez",
+    "birthYear": 1965,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "La Guaira",
+    "warCareer": -2.35
+  },
+  {
+    "playerId": "mcculch01",
+    "fullName": "Charlie McCullough",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Dublin",
+    "warCareer": -2.36
+  },
+  {
+    "playerId": "schauru01",
+    "fullName": "Rube Schauer",
+    "birthYear": 1891,
+    "birthDecade": 1890,
+    "birthCountry": "Russia",
+    "birthCountryRaw": "Russia",
+    "birthCity": "Kamenka",
+    "warCareer": -2.39
+  },
+  {
+    "playerId": "tomasya01",
+    "fullName": "Yasmany Tomas",
+    "birthYear": 1990,
+    "birthDecade": 1990,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -2.39
+  },
+  {
+    "playerId": "fernach01",
+    "fullName": "Chico Fernandez",
+    "birthYear": 1932,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -2.4
+  },
+  {
+    "playerId": "alexama02",
+    "fullName": "Manny Alexander",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -2.42
+  },
+  {
+    "playerId": "osborfr01",
+    "fullName": "Fred Osborne",
+    "birthYear": 1865,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": null,
+    "warCareer": -2.44
+  },
+  {
+    "playerId": "ordazlu01",
+    "fullName": "Luis Ordaz",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Maracaibo",
+    "warCareer": -2.45
+  },
+  {
+    "playerId": "acevejo01",
+    "fullName": "Jose Acevedo",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -2.48
+  },
+  {
+    "playerId": "pierema01",
+    "fullName": "Marino Pieretti",
+    "birthYear": 1920,
+    "birthDecade": 1920,
+    "birthCountry": "Italy",
+    "birthCountryRaw": "Italy",
+    "birthCity": "Luccia",
+    "warCareer": -2.48
+  },
+  {
+    "playerId": "perezro01",
+    "fullName": "Robert Perez",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Ciudad Bolivar",
+    "warCareer": -2.58
+  },
+  {
+    "playerId": "pichero01",
+    "fullName": "Ron Piche",
+    "birthYear": 1935,
+    "birthDecade": 1930,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Verdun",
+    "warCareer": -2.58
+  },
+  {
+    "playerId": "valdese01",
+    "fullName": "Sergio Valdez",
+    "birthYear": 1964,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Elias Pina",
+    "warCareer": -2.59
+  },
+  {
+    "playerId": "myettaa01",
+    "fullName": "Aaron Myette",
+    "birthYear": 1977,
+    "birthDecade": 1970,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "New Westminster",
+    "warCareer": -2.64
+  },
+  {
+    "playerId": "oropeed01",
+    "fullName": "Eddie Oropesa",
+    "birthYear": 1971,
+    "birthDecade": 1970,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Colon",
+    "warCareer": -2.64
+  },
+  {
+    "playerId": "mendoma01",
+    "fullName": "Mario Mendoza",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Chihuahua",
+    "warCareer": -2.69
+  },
+  {
+    "playerId": "sullisl01",
+    "fullName": "Sleeper Sullivan",
+    "birthYear": 1859,
+    "birthDecade": 1850,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": null,
+    "warCareer": -2.69
+  },
+  {
+    "playerId": "martite01",
+    "fullName": "Ted Martinez",
+    "birthYear": 1947,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Barahona",
+    "warCareer": -2.74
+  },
+  {
+    "playerId": "mckayda01",
+    "fullName": "Dave McKay",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "Vancouver",
+    "warCareer": -2.75
+  },
+  {
+    "playerId": "becquju01",
+    "fullName": "Julio Becquer",
+    "birthYear": 1931,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -2.81
+  },
+  {
+    "playerId": "cedenan01",
+    "fullName": "Andujar Cedeno",
+    "birthYear": 1969,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "La Romana",
+    "warCareer": -2.81
+  },
+  {
+    "playerId": "castijo02",
+    "fullName": "Jose Castillo",
+    "birthYear": 1981,
+    "birthDecade": 1980,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Las Mercedes",
+    "warCareer": -2.84
+  },
+  {
+    "playerId": "humphjo01",
+    "fullName": "John Humphries",
+    "birthYear": 1861,
+    "birthDecade": 1860,
+    "birthCountry": "Canada",
+    "birthCountryRaw": "CAN",
+    "birthCity": "North Gower",
+    "warCareer": -2.89
+  },
+  {
+    "playerId": "mollwfr01",
+    "fullName": "Fritz Mollwitz",
+    "birthYear": 1890,
+    "birthDecade": 1890,
+    "birthCountry": "Germany",
+    "birthCountryRaw": "Germany",
+    "birthCity": "Koburg",
+    "warCareer": -2.89
+  },
+  {
+    "playerId": "mercaor01",
+    "fullName": "Orlando Mercado",
+    "birthYear": 1961,
+    "birthDecade": 1960,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": -3.01
+  },
+  {
+    "playerId": "gonzafe01",
+    "fullName": "Fernando Gonzalez",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arecibo",
+    "warCareer": -3.03
+  },
+  {
+    "playerId": "despaod01",
+    "fullName": "Odrisamer Despaigne",
+    "birthYear": 1987,
+    "birthDecade": 1980,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -3.11
+  },
+  {
+    "playerId": "alvarlu01",
+    "fullName": "Luis Alvarado",
+    "birthYear": 1949,
+    "birthDecade": 1940,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Lajas",
+    "warCareer": -3.14
+  },
+  {
+    "playerId": "dowseto01",
+    "fullName": "Tom Dowse",
+    "birthYear": 1866,
+    "birthDecade": 1860,
+    "birthCountry": "Ireland",
+    "birthCountryRaw": "Ireland",
+    "birthCity": "Mohill",
+    "warCareer": -3.17
+  },
+  {
+    "playerId": "guerrmi01",
+    "fullName": "Mike Guerra",
+    "birthYear": 1912,
+    "birthDecade": 1910,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -3.22
+  },
+  {
+    "playerId": "garcika01",
+    "fullName": "Karim Garcia",
+    "birthYear": 1975,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Ciudad Obregon",
+    "warCareer": -3.25
+  },
+  {
+    "playerId": "valdijo01",
+    "fullName": "Jose Valdivielso",
+    "birthYear": 1934,
+    "birthDecade": 1930,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Matanzas",
+    "warCareer": -3.27
+  },
+  {
+    "playerId": "roselda01",
+    "fullName": "Dave Rosello",
+    "birthYear": 1950,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Mayaguez",
+    "warCareer": -3.32
+  },
+  {
+    "playerId": "queveru01",
+    "fullName": "Ruben Quevedo",
+    "birthYear": 1979,
+    "birthDecade": 1970,
+    "birthCountry": "Venezuela",
+    "birthCountryRaw": "Venezuela",
+    "birthCity": "Valencia",
+    "warCareer": -3.44
+  },
+  {
+    "playerId": "rogeres01",
+    "fullName": "Esmil Rogers",
+    "birthYear": 1985,
+    "birthDecade": 1980,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -3.45
+  },
+  {
+    "playerId": "torrehe01",
+    "fullName": "Hector Torres",
+    "birthYear": 1945,
+    "birthDecade": 1940,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Monterrey",
+    "warCareer": -3.55
+  },
+  {
+    "playerId": "gomezch01",
+    "fullName": "Chile Gomez",
+    "birthYear": 1909,
+    "birthDecade": 1900,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Mazatlan",
+    "warCareer": -3.58
+  },
+  {
+    "playerId": "arciajo01",
+    "fullName": "Jose Arcia",
+    "birthYear": 1943,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "La Habana",
+    "warCareer": -3.59
+  },
+  {
+    "playerId": "cruzhe01",
+    "fullName": "Hector Cruz",
+    "birthYear": 1953,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Arroyo",
+    "warCareer": -3.62
+  },
+  {
+    "playerId": "hernaja01",
+    "fullName": "Jackie Hernandez",
+    "birthYear": 1940,
+    "birthDecade": 1940,
+    "birthCountry": "Cuba",
+    "birthCountryRaw": "Cuba",
+    "birthCity": "Central Tinguaro",
+    "warCareer": -3.91
+  },
+  {
+    "playerId": "gomezlu01",
+    "fullName": "Luis Gomez",
+    "birthYear": 1951,
+    "birthDecade": 1950,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Guadalajara",
+    "warCareer": -4.35
+  },
+  {
+    "playerId": "friaspe01",
+    "fullName": "Pepe Frias",
+    "birthYear": 1948,
+    "birthDecade": 1940,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "San Pedro de Macoris",
+    "warCareer": -4.77
+  },
+  {
+    "playerId": "lopezlu02",
+    "fullName": "Luis Lopez",
+    "birthYear": 1970,
+    "birthDecade": 1970,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Cidra",
+    "warCareer": -4.9
+  },
+  {
+    "playerId": "pujollu01",
+    "fullName": "Luis Pujols",
+    "birthYear": 1955,
+    "birthDecade": 1950,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santiago de los Caballeros",
+    "warCareer": -5.18
+  },
+  {
+    "playerId": "romered01",
+    "fullName": "Ed Romero",
+    "birthYear": 1957,
+    "birthDecade": 1950,
+    "birthCountry": "Puerto Rico",
+    "birthCountryRaw": "P.R.",
+    "birthCity": "Santurce",
+    "warCareer": -5.22
+  },
+  {
+    "playerId": "wilsoen01",
+    "fullName": "Enrique Wilson",
+    "birthYear": 1973,
+    "birthDecade": 1970,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Santo Domingo",
+    "warCareer": -5.22
+  },
+  {
+    "playerId": "castrju01",
+    "fullName": "Juan Castro",
+    "birthYear": 1972,
+    "birthDecade": 1970,
+    "birthCountry": "Mexico",
+    "birthCountryRaw": "Mexico",
+    "birthCity": "Los Mochis",
+    "warCareer": -5.4
+  },
+  {
+    "playerId": "gutieja01",
+    "fullName": "Jackie Gutierrez",
+    "birthYear": 1960,
+    "birthDecade": 1960,
+    "birthCountry": "Colombia",
+    "birthCountryRaw": "Colombia",
+    "birthCity": "Cartagena",
+    "warCareer": -5.57
+  },
+  {
+    "playerId": "thomaan01",
+    "fullName": "Andres Thomas",
+    "birthYear": 1963,
+    "birthDecade": 1960,
+    "birthCountry": "Dominican Republic",
+    "birthCountryRaw": "D.R.",
+    "birthCity": "Boca Chica",
+    "warCareer": -5.73
+  }
+]

--- a/scripts/build-datasets.mjs
+++ b/scripts/build-datasets.mjs
@@ -45,6 +45,34 @@ const states = stateMetaData;
 const statesByPostal = new Map(states.map((state) => [state.postal.toUpperCase(), state]));
 const statesByName = new Map(states.map((state) => [state.name.toLowerCase(), state]));
 
+const COUNTRY_ALIASES = new Map([
+  ['USA', 'United States'],
+  ['CAN', 'Canada'],
+  ['D.R.', 'Dominican Republic'],
+  ['P.R.', 'Puerto Rico'],
+  ['V.I.', 'U.S. Virgin Islands']
+]);
+
+function normalizeCountryName(value) {
+  if (!value) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+  const alias = COUNTRY_ALIASES.get(trimmed) ?? COUNTRY_ALIASES.get(trimmed.toUpperCase());
+  return alias ?? trimmed;
+}
+
+function isUnitedStates(value) {
+  if (!value) {
+    return false;
+  }
+  const normalized = String(value).trim().toUpperCase();
+  return normalized === 'USA' || normalized === 'UNITED STATES' || normalized === 'U.S.A.';
+}
+
 function findState(value) {
   if (!value) {
     return undefined;
@@ -71,7 +99,8 @@ async function loadMasterRecords() {
   const masterPath = path.join(publicDir, 'Master.csv');
   const text = await readFile(masterPath, 'utf8');
   const rows = parseCsv(text);
-  const players = new Map();
+  const domesticPlayers = new Map();
+  const internationalPlayers = new Map();
   rows.forEach((row) => {
     const playerId = row.playerID;
     if (!playerId) {
@@ -82,22 +111,39 @@ async function loadMasterRecords() {
       return;
     }
     const state = findState(row.birthState);
-    if (!state) {
-      return;
-    }
     const firstName = row.nameFirst ?? '';
     const lastName = row.nameLast ?? '';
     const fullName = `${firstName} ${lastName}`.trim() || row.nameGiven || playerId;
-    players.set(playerId, {
+    const countryRaw = row.birthCountry ?? '';
+    const normalizedCountry = normalizeCountryName(countryRaw);
+    if (state) {
+      domesticPlayers.set(playerId, {
+        playerId,
+        fullName,
+        birthYear,
+        birthStateRaw: state.postal,
+        birthDecade: Math.floor(birthYear / 10) * 10,
+        warCareer: 0
+      });
+      return;
+    }
+
+    if (!normalizedCountry || isUnitedStates(countryRaw)) {
+      return;
+    }
+
+    internationalPlayers.set(playerId, {
       playerId,
       fullName,
       birthYear,
-      birthStateRaw: state.postal,
       birthDecade: Math.floor(birthYear / 10) * 10,
+      birthCountry: normalizedCountry,
+      birthCountryRaw: countryRaw ? String(countryRaw).trim() || null : null,
+      birthCity: row.birthCity ? String(row.birthCity).trim() || null : null,
       warCareer: 0
     });
   });
-  return players;
+  return { domesticPlayers, internationalPlayers };
 }
 
 function accumulateWar(players, rows) {
@@ -118,19 +164,21 @@ function accumulateWar(players, rows) {
   });
 }
 
-async function buildPlayersDataset() {
-  const players = await loadMasterRecords();
+async function buildPlayerDatasets() {
+  const { domesticPlayers, internationalPlayers } = await loadMasterRecords();
   const zipPath = path.join(publicDir, 'war_archive-2025-09-24.zip');
 
   const battingText = await readZipEntry(zipPath, 'war_daily_bat.txt');
   const battingRows = parseCsv(battingText);
-  accumulateWar(players, battingRows);
+  accumulateWar(domesticPlayers, battingRows);
+  accumulateWar(internationalPlayers, battingRows);
 
   const pitchingText = await readZipEntry(zipPath, 'war_daily_pitch.txt');
   const pitchingRows = parseCsv(pitchingText);
-  accumulateWar(players, pitchingRows);
+  accumulateWar(domesticPlayers, pitchingRows);
+  accumulateWar(internationalPlayers, pitchingRows);
 
-  const playerList = Array.from(players.values())
+  const domesticList = Array.from(domesticPlayers.values())
     .filter((player) => Math.abs(player.warCareer) >= 0.01)
     .map((player) => ({
       ...player,
@@ -138,7 +186,17 @@ async function buildPlayersDataset() {
     }))
     .sort((a, b) => b.warCareer - a.warCareer);
 
-  return playerList;
+  const internationalList = Array.from(internationalPlayers.values())
+    .filter((player) => player.birthCountry && Math.abs(player.warCareer) >= 0.01)
+    .map((player) => ({
+      ...player,
+      warCareer: Number(player.warCareer.toFixed(3)),
+      birthCountryRaw: player.birthCountryRaw ?? null,
+      birthCity: player.birthCity ?? null
+    }))
+    .sort((a, b) => b.warCareer - a.warCareer);
+
+  return { domesticList, internationalList };
 }
 
 async function buildPopulationDataset() {
@@ -179,12 +237,18 @@ async function buildPopulationDataset() {
 
 async function main() {
   await mkdir(dataDir, { recursive: true });
-  const [players, populations] = await Promise.all([buildPlayersDataset(), buildPopulationDataset()]);
+  const [{ domesticList, internationalList }, populations] = await Promise.all([
+    buildPlayerDatasets(),
+    buildPopulationDataset()
+  ]);
 
-  await writeFile(path.join(dataDir, 'players.json'), JSON.stringify(players, null, 2));
+  await writeFile(path.join(dataDir, 'players.json'), JSON.stringify(domesticList, null, 2));
+  await writeFile(path.join(dataDir, 'intplayers.json'), JSON.stringify(internationalList, null, 2));
   await writeFile(path.join(dataDir, 'state-populations.json'), JSON.stringify(populations, null, 2));
 
-  console.log(`Wrote ${players.length} player records and ${populations.length} population entries.`);
+  console.log(
+    `Wrote ${domesticList.length} domestic player records, ${internationalList.length} international player records, and ${populations.length} population entries.`
+  );
 }
 
 main().catch((error) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,9 +98,16 @@ export default function App() {
     }
   }, [view, decades, decadeFocus]);
 
+  const internationalHref = `${(import.meta.env.BASE_URL ?? '/').replace(/\/?$/, '/')}#/international`;
+
   return (
     <div className={styles.app}>
       <header className={styles.header}>
+        <div className={styles.headerNav}>
+          <a className={styles.navLink} href={internationalHref}>
+            International edition →
+          </a>
+        </div>
         <h1>Birthplace WAR Atlas</h1>
         <p className={styles.subtitle}>
           Explore how career WAR is distributed across the United States by birthplace, population, and birth decade.

--- a/src/InternationalApp.tsx
+++ b/src/InternationalApp.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  aggregateByCountry,
+  CountryAggregate,
+  InternationalPlayerRecord,
+  listInternationalDecades,
+  findWarExtent
+} from './utils/internationalData';
+import styles from './styles/InternationalApp.module.css';
+
+const resolveStaticUrl = (relativePath: string) => {
+  const base = import.meta.env.BASE_URL ?? '/';
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  return `${normalizedBase}${relativePath}`;
+};
+
+const DATA_URL = resolveStaticUrl('data/intplayers.json');
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+const warFormatter = new Intl.NumberFormat('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+
+function useHomeHref() {
+  const base = import.meta.env.BASE_URL ?? '/';
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+export default function InternationalApp() {
+  const [players, setPlayers] = useState<InternationalPlayerRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [minWar, setMinWar] = useState(0);
+  const [selectedDecade, setSelectedDecade] = useState<number | 'all'>('all');
+  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchData() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(DATA_URL);
+        if (!response.ok) {
+          throw new Error('Unable to load international players dataset');
+        }
+        const data = (await response.json()) as InternationalPlayerRecord[];
+        if (!cancelled) {
+          setPlayers(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error(err);
+          setError(err instanceof Error ? err.message : 'Unknown error loading dataset');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const decades = useMemo(() => listInternationalDecades(players), [players]);
+
+  useEffect(() => {
+    if (selectedDecade !== 'all' && !decades.includes(selectedDecade)) {
+      setSelectedDecade('all');
+    }
+  }, [decades, selectedDecade]);
+
+  const [, maxWarExtent] = useMemo(() => findWarExtent(players), [players]);
+  const sliderMax = useMemo(() => {
+    const safeMax = Math.max(maxWarExtent, 5);
+    const rounded = Math.ceil(safeMax / 5) * 5;
+    return Math.max(5, rounded);
+  }, [maxWarExtent]);
+
+  useEffect(() => {
+    if (minWar > sliderMax) {
+      setMinWar(sliderMax);
+    }
+  }, [sliderMax, minWar]);
+
+  const aggregates = useMemo(() => aggregateByCountry(players, { minWar, decade: selectedDecade }), [
+    players,
+    minWar,
+    selectedDecade
+  ]);
+
+  useEffect(() => {
+    if (aggregates.length === 0) {
+      setSelectedCountry(null);
+      return;
+    }
+    if (!selectedCountry || !aggregates.some((aggregate) => aggregate.country === selectedCountry)) {
+      setSelectedCountry(aggregates[0].country);
+    }
+  }, [aggregates, selectedCountry]);
+
+  const selectedAggregate: CountryAggregate | null = useMemo(() => {
+    if (!selectedCountry) {
+      return null;
+    }
+    return aggregates.find((aggregate) => aggregate.country === selectedCountry) ?? null;
+  }, [aggregates, selectedCountry]);
+
+  const datasetSummary = useMemo(() => {
+    const countryCount = new Set(players.map((player) => player.birthCountry)).size;
+    const totalWar = players.reduce((sum, player) => sum + player.warCareer, 0);
+    return {
+      playerCount: players.length,
+      countryCount,
+      totalWar: Number(totalWar.toFixed(1))
+    };
+  }, [players]);
+
+  const homeHref = useHomeHref();
+
+  return (
+    <div className={styles.app}>
+      <header className={styles.header}>
+        <div className={styles.topBar}>
+          <a className={styles.navLink} href={homeHref}>
+            ← Back to U.S. atlas
+          </a>
+          <span className={styles.datasetMeta}>
+            {datasetSummary.countryCount} countries · {numberFormatter.format(datasetSummary.playerCount)} players ·{' '}
+            {warFormatter.format(datasetSummary.totalWar)} total WAR
+          </span>
+        </div>
+        <h1>International Birthplace WAR</h1>
+        <p className={styles.subtitle}>
+          Discover how career WAR is distributed among MLB players born outside the continental United States. Filter by
+          birth decade and minimum career WAR to compare each country&apos;s contribution and spotlight their standout stars.
+        </p>
+      </header>
+      <main className={styles.main}>
+        <section className={styles.tableSection}>
+          <div className={styles.controls}>
+            <label className={styles.control}>
+              <span className={styles.controlLabel}>Minimum career WAR</span>
+              <div className={styles.sliderWrapper}>
+                <input
+                  type="range"
+                  min={0}
+                  max={sliderMax}
+                  step={1}
+                  value={minWar}
+                  onChange={(event) => setMinWar(Number(event.target.value))}
+                  aria-label="Minimum career WAR filter"
+                />
+                <span className={styles.sliderValue}>{warFormatter.format(minWar)}</span>
+              </div>
+            </label>
+            <label className={styles.control}>
+              <span className={styles.controlLabel}>Birth decade</span>
+              <select
+                value={selectedDecade === 'all' ? 'all' : String(selectedDecade)}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setSelectedDecade(value === 'all' ? 'all' : Number(value));
+                }}
+                aria-label="Birth decade filter"
+              >
+                <option value="all">All decades</option>
+                {decades.map((decade) => (
+                  <option key={decade} value={String(decade)}>
+                    {decade}s
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          {loading ? (
+            <div className={styles.placeholder}>Loading international player data…</div>
+          ) : error ? (
+            <div className={styles.error}>{error}</div>
+          ) : aggregates.length === 0 ? (
+            <div className={styles.placeholder}>No countries match the current filters.</div>
+          ) : (
+            <div className={styles.tableContainer}>
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Country</th>
+                    <th scope="col">Players</th>
+                    <th scope="col">Total WAR</th>
+                    <th scope="col">Avg. WAR</th>
+                    <th scope="col">Top player</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {aggregates.map((aggregate) => {
+                    const topPlayer = aggregate.players[0];
+                    return (
+                      <tr
+                        key={aggregate.country}
+                        className={aggregate.country === selectedCountry ? styles.selectedRow : undefined}
+                        onClick={() => setSelectedCountry(aggregate.country)}
+                      >
+                        <th scope="row">{aggregate.country}</th>
+                        <td>{numberFormatter.format(aggregate.playerCount)}</td>
+                        <td>{warFormatter.format(aggregate.totalWar)}</td>
+                        <td>{warFormatter.format(aggregate.averageWar)}</td>
+                        <td>
+                          {topPlayer ? (
+                            <span className={styles.topPlayer}>
+                              <span className={styles.playerName}>{topPlayer.fullName}</span>
+                              <span className={styles.playerWar}>{warFormatter.format(topPlayer.warCareer)} WAR</span>
+                            </span>
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+        <aside className={styles.detailPanel}>
+          {selectedAggregate ? (
+            <div className={styles.detailContent}>
+              <h2>{selectedAggregate.country}</h2>
+              <p className={styles.detailSummary}>
+                {numberFormatter.format(selectedAggregate.playerCount)} players ·{' '}
+                {warFormatter.format(selectedAggregate.totalWar)} total WAR ·{' '}
+                {warFormatter.format(selectedAggregate.averageWar)} average WAR
+              </p>
+              <div className={styles.topPlayersList}>
+                <h3>Top contributors</h3>
+                <ol>
+                  {selectedAggregate.players.slice(0, 12).map((player) => (
+                    <li key={player.playerId}>
+                      <div className={styles.playerRow}>
+                        <span className={styles.playerName}>{player.fullName}</span>
+                        <span className={styles.playerMeta}>
+                          {player.birthCity ? `${player.birthCity}, ` : ''}
+                          {player.birthCountry}
+                        </span>
+                        <span className={styles.playerWar}>{warFormatter.format(player.warCareer)} WAR</span>
+                      </div>
+                      <span className={styles.playerBirthYear}>Born {player.birthYear}</span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+          ) : (
+            <div className={styles.placeholder}>Select a country to explore its standout players.</div>
+          )}
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import InternationalApp from './InternationalApp';
 import { DataProvider } from './context/DataContext';
 import './styles/index.css';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
+type Route = 'domestic' | 'international';
+
+const baseUrl = (import.meta.env.BASE_URL ?? '/').replace(/\/?$/, '/');
+
+function resolveRoute(): Route {
+  const { hash, pathname } = window.location;
+  const hashPath = hash.replace(/^#/, '').toLowerCase();
+  if (hashPath.startsWith('/international') || hashPath === 'international') {
+    return 'international';
+  }
+  const relativePath = pathname.startsWith(baseUrl) ? pathname.slice(baseUrl.length) : pathname.slice(1);
+  if (relativePath.toLowerCase().startsWith('international')) {
+    return 'international';
+  }
+  return 'domestic';
+}
+
+function Root() {
+  const [route, setRoute] = useState<Route>(() => resolveRoute());
+
+  useEffect(() => {
+    const handleNavigation = () => {
+      setRoute(resolveRoute());
+    };
+    window.addEventListener('hashchange', handleNavigation);
+    window.addEventListener('popstate', handleNavigation);
+    return () => {
+      window.removeEventListener('hashchange', handleNavigation);
+      window.removeEventListener('popstate', handleNavigation);
+    };
+  }, []);
+
+  if (route === 'international') {
+    return <InternationalApp />;
+  }
+
+  return (
     <DataProvider>
       <App />
     </DataProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Root />
   </React.StrictMode>
 );

--- a/src/styles/App.module.css
+++ b/src/styles/App.module.css
@@ -20,6 +20,32 @@
   overflow: hidden;
 }
 
+.headerNav {
+  position: absolute;
+  top: clamp(1rem, 2.5vw, 1.5rem);
+  right: clamp(1.5rem, 3vw, 2.75rem);
+  z-index: 2;
+}
+
+.navLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(30, 64, 175, 0.35);
+  color: var(--text-strong);
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.navLink:hover {
+  background: rgba(59, 130, 246, 0.45);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
 .header::after {
   content: '';
   position: absolute;

--- a/src/styles/InternationalApp.module.css
+++ b/src/styles/InternationalApp.module.css
@@ -1,0 +1,318 @@
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: 100%;
+  padding: clamp(1.5rem, 3vw, 3rem) clamp(1.5rem, 6vw, 5rem);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  color: var(--text-primary);
+}
+
+.header {
+  position: relative;
+  padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2.75rem);
+  border-radius: 1.75rem;
+  border: 1px solid var(--border-soft);
+  background: linear-gradient(150deg, rgba(8, 47, 73, 0.92), rgba(17, 94, 89, 0.78));
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.header::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 12% 18%, rgba(45, 212, 191, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 82%, rgba(14, 165, 233, 0.3), transparent 60%),
+    radial-gradient(circle at 45% 100%, rgba(34, 211, 238, 0.2), transparent 68%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.topBar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.navLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.05rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--text-strong);
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.navLink:hover {
+  background: rgba(30, 64, 175, 0.4);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.datasetMeta {
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.95rem;
+}
+
+.header h1 {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.9rem);
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+}
+
+.subtitle {
+  position: relative;
+  z-index: 1;
+  margin: 0.85rem 0 0;
+  max-width: 760px;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 1.05rem;
+}
+
+.main {
+  display: grid;
+  grid-template-columns: minmax(0, 2.4fr) minmax(280px, 1fr);
+  gap: clamp(1.75rem, 3.5vw, 3rem);
+  align-items: start;
+  width: 100%;
+}
+
+.tableSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-width: 200px;
+}
+
+.controlLabel {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.sliderWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.sliderWrapper input[type='range'] {
+  flex: 1;
+}
+
+.sliderValue {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.control select {
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-strong);
+  font-weight: 500;
+}
+
+.tableContainer {
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), var(--shadow-soft);
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(30, 58, 138, 0.55);
+}
+
+thead th {
+  text-align: left;
+  padding: 0.9rem 1.1rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
+  font-weight: 600;
+}
+
+tbody tr {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.5);
+}
+
+tbody tr:hover {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.selectedRow {
+  background: rgba(59, 130, 246, 0.35) !important;
+}
+
+td,
+th[scope='row'] {
+  padding: 0.85rem 1.1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+th[scope='row'] {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.topPlayer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.playerName {
+  font-weight: 600;
+}
+
+.playerWar {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.detailPanel {
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(8, 47, 73, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), var(--shadow-soft);
+  min-height: 100%;
+  overflow: hidden;
+}
+
+.detailContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.detailContent h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  color: var(--text-strong);
+}
+
+.detailSummary {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+  font-weight: 500;
+}
+
+.topPlayersList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.topPlayersList h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--text-strong);
+}
+
+.topPlayersList ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.playerRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.playerMeta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.playerBirthYear {
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.8rem;
+}
+
+.placeholder {
+  border: 1px dashed rgba(148, 163, 184, 0.45);
+  padding: 2.25rem;
+  text-align: center;
+  border-radius: 1.25rem;
+  color: var(--text-muted);
+  font-style: italic;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.error {
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  background: rgba(220, 38, 38, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+  text-align: center;
+}
+
+@media (max-width: 1080px) {
+  .main {
+    grid-template-columns: 1fr;
+  }
+
+  .detailPanel {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    padding: clamp(1rem, 6vw, 1.75rem);
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/utils/internationalData.ts
+++ b/src/utils/internationalData.ts
@@ -1,0 +1,80 @@
+import { extent } from 'd3-array';
+
+export interface InternationalPlayerRecord {
+  playerId: string;
+  fullName: string;
+  birthYear: number;
+  birthDecade: number;
+  birthCountry: string;
+  birthCountryRaw: string | null;
+  birthCity: string | null;
+  warCareer: number;
+}
+
+export interface CountryAggregate {
+  country: string;
+  totalWar: number;
+  playerCount: number;
+  averageWar: number;
+  players: InternationalPlayerRecord[];
+}
+
+export function listInternationalDecades(players: InternationalPlayerRecord[]): number[] {
+  const decades = new Set<number>();
+  players.forEach((player) => decades.add(player.birthDecade));
+  return Array.from(decades).sort((a, b) => a - b);
+}
+
+export function findWarExtent(players: InternationalPlayerRecord[]): [number, number] {
+  if (players.length === 0) {
+    return [0, 0];
+  }
+  const [min, max] = extent(players, (player) => player.warCareer);
+  return [min ?? 0, max ?? 0];
+}
+
+export function aggregateByCountry(
+  players: InternationalPlayerRecord[],
+  options?: { minWar?: number; decade?: number | 'all' }
+): CountryAggregate[] {
+  const minWar = options?.minWar ?? 0;
+  const decade = options?.decade ?? 'all';
+
+  const filtered = players.filter((player) => {
+    if (player.warCareer < minWar) {
+      return false;
+    }
+    if (decade !== 'all' && player.birthDecade !== decade) {
+      return false;
+    }
+    return true;
+  });
+
+  const aggregates = new Map<string, InternationalPlayerRecord[]>();
+
+  filtered.forEach((player) => {
+    const list = aggregates.get(player.birthCountry) ?? [];
+    list.push(player);
+    aggregates.set(player.birthCountry, list);
+  });
+
+  return Array.from(aggregates.entries())
+    .map(([country, list]) => {
+      const sortedPlayers = [...list].sort((a, b) => b.warCareer - a.warCareer);
+      const totalWar = sortedPlayers.reduce((sum, player) => sum + player.warCareer, 0);
+      const averageWar = totalWar / sortedPlayers.length;
+      return {
+        country,
+        totalWar: Number(totalWar.toFixed(3)),
+        playerCount: sortedPlayers.length,
+        averageWar: Number(averageWar.toFixed(3)),
+        players: sortedPlayers
+      } satisfies CountryAggregate;
+    })
+    .sort((a, b) => {
+      if (b.totalWar === a.totalWar) {
+        return a.country.localeCompare(b.country);
+      }
+      return b.totalWar - a.totalWar;
+    });
+}


### PR DESCRIPTION
## Summary
- extend the dataset build script to normalize country metadata and emit a new `intplayers.json` file alongside the existing outputs
- add the generated international dataset to `public/data` and create utilities and styles to aggregate players by country
- implement an international explorer page with filters, navigation links, and routing to keep the existing U.S. view untouched

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d56ffd59248327a94628ebc2d3d2b3